### PR TITLE
Make Cores optional for Space Planning Zones

### DIFF
--- a/ZonePlanningFunctions/SpacePlanningZones/dependencies/SpacePlanningZones.Dependencies.csproj
+++ b/ZonePlanningFunctions/SpacePlanningZones/dependencies/SpacePlanningZones.Dependencies.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="0.8.5-alpha.0" />
+    <PackageReference Include="Hypar.Elements" Version="0.8.5-alpha.9" />
   </ItemGroup>
 
 </Project>

--- a/ZonePlanningFunctions/SpacePlanningZones/hypar.json
+++ b/ZonePlanningFunctions/SpacePlanningZones/hypar.json
@@ -12,7 +12,7 @@
         {
             "autohide": false,
             "name": "Core",
-            "optional": false
+            "optional": true
         },
         {
             "name": "Floors",

--- a/ZonePlanningFunctions/SpacePlanningZones/src/SpacePlanningZones.cs
+++ b/ZonePlanningFunctions/SpacePlanningZones/src/SpacePlanningZones.cs
@@ -26,18 +26,15 @@ namespace SpacePlanningZones
             var levelsModel = inputModels["Levels"];
             var levelVolumes = levelsModel.AllElementsOfType<LevelVolume>();
             inputModels.TryGetValue("Floors", out var floorsModel);
-            var coresModel = inputModels["Core"];
-            var cores = coresModel.AllElementsOfType<ServiceCore>();
+            var hasCore = inputModels.TryGetValue("Core", out var coresModel);
+            var cores = coresModel?.AllElementsOfType<ServiceCore>() ?? new List<ServiceCore>();
+
             var random = new Random(5);
             var levels = new List<LevelElements>();
             var levelMappings = new Dictionary<Guid, (SpaceBoundary boundary, LevelElements level)>();
             if (levelVolumes.Count() == 0)
             {
                 throw new Exception("This function requires LevelVolumes, produced by functions like \"Simple Levels by Envelope\". Try using a different levels function.");
-            }
-            if (cores.Count() == 0)
-            {
-                throw new Exception("No ServiceCore elements were found in the model.");
             }
             foreach (var lvl in levelVolumes)
             {
@@ -156,7 +153,7 @@ namespace SpacePlanningZones
                     {
                         var crvB = allCenterLines[j].centerLine;
                         var doesIntersect = crvA.Intersects(crvB, out var intersection, true, true);
-                        Console.WriteLine($"DOES INTERSECT: " + doesIntersect.ToString());
+                        // Console.WriteLine($"DOES INTERSECT: " + doesIntersect.ToString());
 
                         var nearPtA = intersection.ClosestPointOn(crvA);
                         var nearPtB = intersection.ClosestPointOn(crvB);
@@ -301,9 +298,9 @@ namespace SpacePlanningZones
                                         segmentsExtended.Add(endLine.ToPolyline(1));
                                     }
                                 }
-                                Console.WriteLine(JsonConvert.SerializeObject(linearZone.Perimeter));
-                                Console.WriteLine(JsonConvert.SerializeObject(linearZone.Voids));
-                                Console.WriteLine(JsonConvert.SerializeObject(segmentsExtended));
+                                // Console.WriteLine(JsonConvert.SerializeObject(linearZone.Perimeter));
+                                // Console.WriteLine(JsonConvert.SerializeObject(linearZone.Voids));
+                                // Console.WriteLine(JsonConvert.SerializeObject(segmentsExtended));
                                 var splits = Profile.Split(new[] { linearZone }, segmentsExtended, Vector3.EPSILON);
                                 spaceBoundaries.AddRange(splits.Select(s => SpaceBoundary.Make(s, input.DefaultProgramAssignment, lvl.Transform, lvl.Height)));
                             }

--- a/ZonePlanningFunctions/SpacePlanningZones/src/SpacePlanningZones.csproj
+++ b/ZonePlanningFunctions/SpacePlanningZones/src/SpacePlanningZones.csproj
@@ -5,8 +5,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="0.8.5-alpha.0" />
-    <PackageReference Include="Hypar.Functions" Version="0.8.7-alpha6" />
+    <PackageReference Include="Hypar.Elements" Version="0.8.5-alpha.9" />
+    <PackageReference Include="Hypar.Functions" Version="0.8.8" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/ZonePlanningFunctions/SpacePlanningZones/test/SpacePlanningZones.Tests.csproj
+++ b/ZonePlanningFunctions/SpacePlanningZones/test/SpacePlanningZones.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Model" Version="0.8.7-alpha6" />
+    <PackageReference Include="Hypar.Model" Version="0.8.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />


### PR DESCRIPTION
### Background
per https://www.notion.so/hyparaec/Next-Steps-d4f8e2d055064598bdeed89e50cc9e3a, we would like to make it possible to use the tool without the presence of a Core element. 

### Description
- Make `Core` dependency optional
- remove some unnecessary log statements
- Update library versions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/hyparspace/2)
<!-- Reviewable:end -->
