### PR TITLE
add manual circulation options

### DIFF
--- a/ZonePlanningFunctions/SpacePlanningZones/README.md
+++ b/ZonePlanningFunctions/SpacePlanningZones/README.md
@@ -2,11 +2,15 @@
 
 # Space Planning Zones
 
-Generate a circulation path and high-level zones for a schematic space plan.
+TEST - Generate a circulation path and high-level zones for a schematic space plan.
 
 |Input Name|Type|Description|
 |---|---|---|
 |Default Program Assignment|string|What would you like the default program for all zones to be? This program type will be assigned to all spaces, and then you can pick specific programs for individual spaces with the Edit Program Assignments button.|
+|Circulation Mode|string|How should circulation be calculated? 
+Automatic: a typical circulation network will be generated for you. 
+Manual: you draw the circulation paths yourself.|
+|Corridors|array|Define the circulation network by drawing one or more corridor paths.|
 |Corridor Width|number|How wide should circulation paths be?|
 |Outer Band Depth|number|For the "outer band" of program running along the floor perimeter, how deep should the spaces be?|
 |Depth at Ends|number|If your floorplate is rectangular, or has roughly rectangular ends, how deep should the spaces be at these ends?|

--- a/ZonePlanningFunctions/SpacePlanningZones/README.md
+++ b/ZonePlanningFunctions/SpacePlanningZones/README.md
@@ -2,7 +2,7 @@
 
 # Space Planning Zones
 
-TEST - Generate a circulation path and high-level zones for a schematic space plan.
+Generate a circulation path and high-level zones for a schematic space plan.
 
 |Input Name|Type|Description|
 |---|---|---|

--- a/ZonePlanningFunctions/SpacePlanningZones/hypar.json
+++ b/ZonePlanningFunctions/SpacePlanningZones/hypar.json
@@ -2,9 +2,10 @@
     "$schema": "https://hypar.io/Schemas/Function.json",
     "id": "09b8407f-6c93-4741-ad6c-31288213f4f7",
     "name": "Space Planning Zones",
-    "description": "Generate a circulation path and high-level zones for a schematic space plan.",
+    "description": "TEST - Generate a circulation path and high-level zones for a schematic space plan.",
     "language": "C#",
-    "model_dependencies": [{
+    "model_dependencies": [
+        {
             "autohide": false,
             "name": "Levels",
             "optional": false
@@ -41,7 +42,45 @@
                 ],
                 "default": "unspecified"
             },
+            "Circulation Mode": {
+                "description": "How should circulation be calculated? \nAutomatic: a typical circulation network will be generated for you. \nManual: you draw the circulation paths yourself.",
+                "type": "string",
+                "enum": [
+                    "Automatic",
+                    "Manual"
+                ],
+                "default": "Automatic"
+            },
+            "Corridors": {
+                "$hyparShowIf": {
+                    "conditions": [
+                        {
+                            "property": "Circulation Mode",
+                            "value": "Manual"
+                        }
+                    ]
+                },
+                "type": "array",
+                "description": "Define the circulation network by drawing one or more corridor paths.",
+                "items": {
+                    "$ref": "https://prod-api.hypar.io/schemas/ThickenedPolyline.json",
+                    "$hyparAllowIntersection": true,
+                    "$hyparConstrainToGround": true,
+                    "default": {
+                        "width": 1.5,
+                        "flip": false
+                    }
+                }
+            },
             "Corridor Width": {
+                "$hyparShowIf": {
+                    "conditions": [
+                        {
+                            "property": "Circulation Mode",
+                            "value": "Automatic"
+                        }
+                    ]
+                },
                 "description": "How wide should circulation paths be?",
                 "type": "number",
                 "minimum": 0.3,
@@ -50,6 +89,14 @@
                 "$hyparUnitType": "length"
             },
             "Outer Band Depth": {
+                "$hyparShowIf": {
+                    "conditions": [
+                        {
+                            "property": "Circulation Mode",
+                            "value": "Automatic"
+                        }
+                    ]
+                },
                 "type": "number",
                 "description": "For the \"outer band\" of program running along the floor perimeter, how deep should the spaces be?",
                 "minimum": 1.0,
@@ -59,6 +106,14 @@
                 "$hyparUnitType": "length"
             },
             "Depth at Ends": {
+                "$hyparShowIf": {
+                    "conditions": [
+                        {
+                            "property": "Circulation Mode",
+                            "value": "Automatic"
+                        }
+                    ]
+                },
                 "type": "number",
                 "description": "If your floorplate is rectangular, or has roughly rectangular ends, how deep should the spaces be at these ends?",
                 "minimum": 1.0,
@@ -68,6 +123,14 @@
                 "$hyparUnitType": "length"
             },
             "Additional Corridor Locations": {
+                "$hyparShowIf": {
+                    "conditions": [
+                        {
+                            "property": "Circulation Mode",
+                            "value": "Automatic"
+                        }
+                    ]
+                },
                 "$hyparDisplayName": "Add Corridors",
                 "description": "Add new points to this list to insert additional corridor locations, to further subdivide the space. Corridors extend perpendicularly from the closest point on the boundary.",
                 "type": "array",

--- a/ZonePlanningFunctions/SpacePlanningZones/hypar.json
+++ b/ZonePlanningFunctions/SpacePlanningZones/hypar.json
@@ -2,7 +2,7 @@
     "$schema": "https://hypar.io/Schemas/Function.json",
     "id": "09b8407f-6c93-4741-ad6c-31288213f4f7",
     "name": "Space Planning Zones",
-    "description": "TEST - Generate a circulation path and high-level zones for a schematic space plan.",
+    "description": "Generate a circulation path and high-level zones for a schematic space plan.",
     "language": "C#",
     "model_dependencies": [
         {

--- a/ZonePlanningFunctions/SpacePlanningZones/src/SpacePlanningZones.cs
+++ b/ZonePlanningFunctions/SpacePlanningZones/src/SpacePlanningZones.cs
@@ -38,7 +38,6 @@ namespace SpacePlanningZones
             }
             foreach (var lvl in levelVolumes)
             {
-                var spaceBoundaries = new List<Element>();
                 if (floorsModel != null)
                 {
                     var floorAtLevel = floorsModel.AllElementsOfType<Floor>().FirstOrDefault(f => Math.Abs(lvl.Transform.Origin.Z - f.Transform.Origin.Z) < (f.Thickness * 1.1));
@@ -53,8 +52,6 @@ namespace SpacePlanningZones
                         }
                     }
                 }
-                List<Profile> corridorProfiles = new List<Profile>();
-                var TOO_SHORT = 9;
                 var levelBoundary = new Profile(lvl.Profile.Perimeter, lvl.Profile.Voids, Guid.NewGuid(), null);
                 var coresInBoundary = cores.Where(c => levelBoundary.Contains(c.Centroid)).ToList();
                 foreach (var core in coresInBoundary)
@@ -63,270 +60,60 @@ namespace SpacePlanningZones
                     levelBoundary.OrientVoids();
                 }
 
-                var perimeter = levelBoundary.Perimeter;
-                var perimeterSegments = perimeter.Segments();
-                var perimeterAngles = new List<double>();
-                for (int i = 0; i < perimeter.Vertices.Count; i++)
+                var spaceBoundaries = new List<Element>();
+                List<Profile> corridorProfiles = new List<Profile>();
+                if (input.CirculationMode == SpacePlanningZonesInputsCirculationMode.Automatic)
                 {
-                    var nextIndex = (i + 1) % perimeter.Vertices.Count;
-                    var prevIndex = (i + perimeter.Vertices.Count - 1) % perimeter.Vertices.Count;
-                    var prevVec = perimeter.Vertices[i] - perimeter.Vertices[prevIndex];
-                    var nextVec = perimeter.Vertices[nextIndex] - perimeter.Vertices[i];
-                    var angle = prevVec.PlaneAngleTo(nextVec);
-                    perimeterAngles.Add(angle);
+                    var perimeter = levelBoundary.Perimeter;
+                    var perimeterSegments = perimeter.Segments();
+
+                    IdentifyShortEdges(perimeter, perimeterSegments, out var shortEdges, out var shortEdgeIndices);
+
+                    // Single Loaded Zones
+                    var singleLoadedZones = CalculateSingleLoadedZones(input, corridorWidth, perimeterSegments, shortEdgeIndices);
+
+                    GenerateEndZones(input, corridorWidth, lvl, corridorProfiles, perimeterSegments, shortEdges, singleLoadedZones, out var thickenedEnds, out var thickerOffsetProfiles, out var innerOffsetMinusThickenedEnds, out var exclusionRegions);
+
+                    // join single loaded zones to each other (useful in bent-bar case)
+                    var allCenterLines = JoinSingleLoaded(singleLoadedZones);
+
+                    // thicken and extend single loaded
+                    ThickenAndExtendSingleLoaded(corridorWidth, corridorProfiles, coresInBoundary, thickenedEnds, innerOffsetMinusThickenedEnds, allCenterLines);
+
+                    CorridorsFromCore(corridorWidth, corridorProfiles, levelBoundary, coresInBoundary, innerOffsetMinusThickenedEnds, exclusionRegions);
+
+                    SplitCornersAndGenerateSpaceBoundaries(spaceBoundaries, input, lvl, corridorProfiles, levelBoundary, thickerOffsetProfiles);
                 }
-                var allLengths = perimeterSegments.Select(s => s.Length());
-                var validLengths = allLengths.Where(l => l > TOO_SHORT)?.OrderBy(l => l);
-                var shortLength = (validLengths?.FirstOrDefault() ?? 35 / 1.2) * 1.2;
-                var longLength = Math.Min(validLengths.SkipLast(1).Last(), 50);
-                var shortEdges = new List<Line>();
-                var shortEdgeIndices = new List<int>();
-                for (int i = 0; i < perimeterSegments.Count(); i++)
+                else if (input.CirculationMode == SpacePlanningZonesInputsCirculationMode.Manual)
                 {
-                    var start = perimeterAngles[i];
-                    var end = perimeterAngles[(i + 1) % perimeterAngles.Count];
-                    if (start > 80 && start < 100 && end > 80 && end < 100 && perimeterSegments[i].Length() < longLength)
+                    if (input.Corridors != null && input.Corridors.Count > 0)
                     {
-                        shortEdges.Add(perimeterSegments[i]);
-                        shortEdgeIndices.Add(i);
-                    }
-                }
-
-
-                // Single Loaded Zones
-
-                var singleLoadedZones = new List<(Polygon hull, Line centerLine)>();
-                var singleLoadedLengthThreshold = input.OuterBandDepth * 2 + corridorWidth * 2 + 5; // (two offsets, two corridors, and a usable space width)
-                foreach (var sei in shortEdgeIndices)
-                {
-                    var ps = perimeterSegments;
-                    if (ps[sei].Length() < singleLoadedLengthThreshold)
-                    {
-                        var legSegments = new[] {
-                            ps[(sei + ps.Length -1) % ps.Length],
-                            ps[sei],
-                            ps[(sei + 1) % ps.Length]
-                        };
-                        var legLength = Math.Min(legSegments[0].Length(), legSegments[2].Length());
-                        legSegments[0] = new Line(ps[sei].Start, ps[sei].Start + legLength * (legSegments[0].Direction() * -1));
-                        legSegments[2] = new Line(ps[sei].End, ps[sei].End + legLength * (legSegments[2].Direction()));
-                        var hull = ConvexHull.FromPolylines(legSegments.Select(l => l.ToPolyline(1)));
-                        var centerLine = new Line((legSegments[0].Start + legSegments[2].Start) / 2, (legSegments[0].End + legSegments[2].End) / 2);
-
-                        singleLoadedZones.Add((hull, centerLine));
-                    }
-
-                }
-
-                var shortEdgesExtended = shortEdges.Select(l => new Line(l.Start - l.Direction() * 0.2, l.End + l.Direction() * 0.2));
-                var longEdges = perimeterSegments.Except(shortEdges);
-                var shortEdgeDepth = Math.Max(input.DepthAtEnds, input.OuterBandDepth);
-                var longEdgeDepth = input.OuterBandDepth;
-
-
-                var perimeterMinusSingleLoaded = new List<Profile>();
-                perimeterMinusSingleLoaded.AddRange(Profile.Difference(new[] { lvl.Profile }, singleLoadedZones.Select(p => new Profile(p.hull))));
-                var innerOffset = perimeterMinusSingleLoaded.SelectMany(p => p.Perimeter.Offset(-longEdgeDepth));
-                var thickerOffsets = shortEdgesExtended.SelectMany(s => s.ToPolyline(1).Offset(shortEdgeDepth, EndType.Butt)).ToList();
-                var thickerOffsetProfiles = thickerOffsets.Select(o => new Profile(o.Offset(0.01))).ToList();
-                var endOffsetSegments = thickerOffsets.SelectMany(o => o.Segments()).Where(l => innerOffset.Any(o => o.Contains(l.PointAt(0.5))));
-
-                var innerOffsetMinusThicker = innerOffset.SelectMany(i => Polygon.Difference(new[] { i }, thickerOffsets));
-
-                var outerband = new Profile(lvl.Profile.Perimeter, innerOffsetMinusThicker.ToList(), Guid.NewGuid(), null);
-
-                var outerbandLongEdges = Profile.Difference(new List<Profile> { outerband }, thickerOffsetProfiles);
-                var ends = Profile.Intersection(new List<Profile> { outerband }, thickerOffsets.Select(o => new Profile(o)).ToList());
-                var coreSegments = coresInBoundary.SelectMany(c => c.Profile.Perimeter.Offset((corridorWidth / 2) * 0.999).FirstOrDefault()?.Segments());
-
-
-                var corridorInset = innerOffsetMinusThicker.Select(p => new Profile(p, p.Offset(-corridorWidth), Guid.NewGuid(), "Corridor"));
-                corridorProfiles.AddRange(corridorInset);
-
-                // join single loaded zones to each other (useful in bent-bar case)
-                var allCenterLines = singleLoadedZones.ToArray();
-                var distanceThreshold = 10.0;
-                for (int i = 0; i < allCenterLines.Count(); i++)
-                {
-                    var crvA = allCenterLines[i].centerLine;
-                    for (int j = 0; j < i; j++)
-                    {
-                        var crvB = allCenterLines[j].centerLine;
-                        var doesIntersect = crvA.Intersects(crvB, out var intersection, true, true);
-                        // Console.WriteLine($"DOES INTERSECT: " + doesIntersect.ToString());
-
-                        var nearPtA = intersection.ClosestPointOn(crvA);
-                        var nearPtB = intersection.ClosestPointOn(crvB);
-                        if (nearPtA.DistanceTo(intersection) + nearPtB.DistanceTo(intersection) < distanceThreshold)
+                        var corridorProfilesForUnion = new List<Profile>();
+                        foreach (var corridorPolyline in input.Corridors)
                         {
-                            if (nearPtA.DistanceTo(crvA.Start) < 0.01)
+                            if (corridorPolyline == null || corridorPolyline.Polyline == null)
                             {
-                                allCenterLines[i] = (allCenterLines[i].hull, new Line(intersection, crvA.End));
+                                continue;
                             }
-                            else
-                            {
-                                allCenterLines[i] = (allCenterLines[i].hull, new Line(crvA.Start, intersection));
-                            }
-                            if (nearPtB.DistanceTo(crvB.Start) < 0.01)
-                            {
-                                allCenterLines[j] = (allCenterLines[j].hull, new Line(intersection, crvB.End));
-                            }
-                            else
-                            {
-                                allCenterLines[j] = (allCenterLines[j].hull, new Line(crvB.Start, intersection));
-                            }
+                            var corrPgons = corridorPolyline.Polyline.OffsetOnSide(corridorPolyline.Width, corridorPolyline.Flip);
+                            corridorProfilesForUnion.AddRange(corrPgons.Select(p => new Profile(p)));
                         }
-
+                        corridorProfiles = Profile.UnionAll(corridorProfilesForUnion);
                     }
+                    SplitCornersAndGenerateSpaceBoundaries(spaceBoundaries, input, lvl, corridorProfiles, levelBoundary);
                 }
 
-
-                // thicken and extend single loaded
-                foreach (var singleLoadedZone in allCenterLines)
-                {
-                    var cl = singleLoadedZone.centerLine;
-                    List<Line> centerlines = new List<Line> { cl };
-                    foreach (var core in coresInBoundary)
-                    {
-                        List<Line> linesRunning = new List<Line>();
-                        foreach (var curve in centerlines)
-                        {
-                            curve.Trim(core.Profile.Perimeter, out var linesTrimmedByCore);
-                            linesRunning.AddRange(linesTrimmedByCore);
-                        }
-                        centerlines = linesRunning;
-                    }
-                    cl = centerlines.OrderBy(l => l.Length()).Last();
-                    foreach (var clCandidate in centerlines)
-                    {
-
-                        var extended = clCandidate.ExtendTo(innerOffsetMinusThicker.SelectMany(p => p.Segments())).ToPolyline(1);
-                        if (extended.Length() == cl.Length() && innerOffsetMinusThicker.Count() > 0)
-                        {
-                            var end = extended.End;
-                            var dist = double.MaxValue;
-                            Vector3? runningPt = null;
-                            foreach (var boundary in innerOffsetMinusThicker)
-                            {
-                                var closestDist = end.DistanceTo(boundary, out var pt);
-                                if (closestDist < dist)
-                                {
-                                    dist = closestDist;
-                                    runningPt = pt;
-                                }
-                            }
-                            extended = new Polyline(new[] { extended.Start, extended.End, runningPt.Value });
-                        }
-                        //TODO - verify that newly constructed line is contained within building perimeter
-                        var thickenedCorridor = extended.Offset(corridorWidth / 2.0, EndType.Square);
-                        corridorProfiles.AddRange(Profile.Difference(thickenedCorridor.Select(c => new Profile(c)), thickerOffsets.Select(c => new Profile(c))));
-                    }
-
-                }
-
-                foreach (var core in coresInBoundary)
-                {
-                    if (singleLoadedZones.Any(z => z.hull.Covers(core.Profile.Perimeter)))
-                    {
-                        continue;
-                    }
-                    var boundary = core.Profile.Perimeter.Offset(corridorWidth / 2.0).FirstOrDefault();
-                    var outerOffset = boundary.Offset(corridorWidth).FirstOrDefault();
-                    var coreWrap = new Profile(outerOffset, boundary);
-                    var coreWrapWithinFloor = Profile.Intersection(new[] { coreWrap }, new[] { levelBoundary });
-                }
-
-                var extendedLines = new List<Line>();
-                var corridorRegions = new List<Polygon>();
-                var exclusionRegions = innerOffsetMinusThicker.SelectMany(r => r.Offset(2 * corridorWidth, EndType.Square));
-                foreach (var enclosedRegion in innerOffsetMinusThicker)
-                {
-                    foreach (var segment in coreSegments)
-                    {
-                        enclosedRegion.Contains(segment.Start, out var startContainment);
-                        enclosedRegion.Contains(segment.End, out var endContainment);
-                        if (endContainment == Containment.Outside && startContainment == Containment.Outside)
-                        {
-                            continue;
-                        }
-                        var extendedSegment = segment.ExtendTo(new Profile(enclosedRegion));
-                        if (extendedSegment.Length() - segment.Length() < 2 * 8)
-                        {
-                            continue;
-                        }
-                        extendedLines.Add(extendedSegment);
-                        var thickenedCorridor = extendedSegment.ToPolyline(1).Offset(corridorWidth / 2.0, EndType.Butt);
-                        var difference = new List<Profile>();
-
-                        difference = Profile.Difference(corridorProfiles, exclusionRegions.Select(r => new Profile(r)));
-
-                        if (difference.Count > 0 && difference.Sum(d => d.Perimeter.Area()) > 10)
-                        {
-                            corridorProfiles.AddRange(Profile.Intersection(thickenedCorridor.Select(c => new Profile(c)), new[] { levelBoundary }));
-                        }
-                    }
-                }
-
-                var remainingSpaces = Profile.Difference(new[] { levelBoundary }, corridorProfiles);
-                foreach (var remainingSpace in remainingSpaces)
-                {
-                    try
-                    {
-                        if (remainingSpace.Perimeter.Vertices.Any(v => v.DistanceTo(levelBoundary.Perimeter) < 0.1))
-                        {
-                            var endCapZones = Profile.Intersection(new[] { remainingSpace }, thickerOffsetProfiles);
-                            var linearZones = Profile.Difference(new[] { remainingSpace }, thickerOffsetProfiles);
-                            foreach (var linearZone in linearZones)
-                            {
-                                var segmentsExtended = new List<Polyline>();
-                                foreach (var line in linearZone.Segments())
-                                {
-                                    if (line.Length() < 2) continue;
-                                    var l = new Line(line.Start - line.Direction() * 0.1, line.End + line.Direction() * 0.1);
-                                    var extended = l.ExtendTo(linearZone);
-                                    var endDistance = extended.End.DistanceTo(l.End);
-                                    var startDistance = extended.Start.DistanceTo(l.Start);
-                                    var maxExtension = Math.Max(input.OuterBandDepth, input.DepthAtEnds) * 1.6;
-                                    if (startDistance > 0.1 && startDistance < maxExtension)
-                                    {
-                                        var startLine = new Line(extended.Start, line.Start);
-                                        segmentsExtended.Add(startLine.ToPolyline(1));
-                                    }
-                                    if (endDistance > 0.1 && endDistance < maxExtension)
-                                    {
-                                        var endLine = new Line(extended.End, line.End);
-                                        segmentsExtended.Add(endLine.ToPolyline(1));
-                                    }
-                                }
-                                // Console.WriteLine(JsonConvert.SerializeObject(linearZone.Perimeter));
-                                // Console.WriteLine(JsonConvert.SerializeObject(linearZone.Voids));
-                                // Console.WriteLine(JsonConvert.SerializeObject(segmentsExtended));
-                                var splits = Profile.Split(new[] { linearZone }, segmentsExtended, Vector3.EPSILON);
-                                spaceBoundaries.AddRange(splits.Select(s => SpaceBoundary.Make(s, input.DefaultProgramAssignment, lvl.Transform, lvl.Height)));
-                            }
-                            spaceBoundaries.AddRange(endCapZones.Select(s => SpaceBoundary.Make(s, input.DefaultProgramAssignment, lvl.Transform, lvl.Height)));
-                        }
-                        else
-                        {
-                            spaceBoundaries.Add(SpaceBoundary.Make(remainingSpace, input.DefaultProgramAssignment, lvl.Transform, lvl.Height));
-                        }
-                    }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine("🚨");
-                        Console.WriteLine(e.Message);
-                        Console.WriteLine(e.StackTrace);
-                        spaceBoundaries.Add(SpaceBoundary.Make(remainingSpace, input.DefaultProgramAssignment, lvl.Transform, lvl.Height));
-                    }
-                }
+                // Construct Level 
                 var level = new LevelElements(new List<Element>(), Guid.NewGuid(), lvl.Name);
                 levels.Add(level);
 
+                // Manual Corridor Splits
                 foreach (var pt in input.AdditionalCorridorLocations)
                 {
                     SplitZones(input, corridorWidth, lvl, spaceBoundaries, corridorProfiles, pt);
                 }
 
+                // Manual Split Locations
                 foreach (var pt in input.ManualSplitLocations)
                 {
                     SplitZones(input, corridorWidth, lvl, spaceBoundaries, corridorProfiles, pt, false);
@@ -418,6 +205,268 @@ namespace SpacePlanningZones
             output.Model.AddElements(areas.Select(kvp => kvp.Value).OrderByDescending(a => a.AchievedArea));
             output.Model.AddElements(levels);
             return output;
+        }
+
+        private static void IdentifyShortEdges(Polygon perimeter, Line[] perimeterSegments, out List<Line> shortEdges, out List<int> shortEdgeIndices)
+        {
+            var TOO_SHORT = 9.0;
+            var perimeterAngles = new List<double>();
+            for (int i = 0; i < perimeter.Vertices.Count; i++)
+            {
+                var nextIndex = (i + 1) % perimeter.Vertices.Count;
+                var prevIndex = (i + perimeter.Vertices.Count - 1) % perimeter.Vertices.Count;
+                var prevVec = perimeter.Vertices[i] - perimeter.Vertices[prevIndex];
+                var nextVec = perimeter.Vertices[nextIndex] - perimeter.Vertices[i];
+                var angle = prevVec.PlaneAngleTo(nextVec);
+                perimeterAngles.Add(angle);
+            }
+            var allLengths = perimeterSegments.Select(s => s.Length());
+            var validLengths = allLengths.Where(l => l > TOO_SHORT)?.OrderBy(l => l);
+            var shortLength = (validLengths?.FirstOrDefault() ?? 35 / 1.2) * 1.2;
+            var longLength = Math.Min(validLengths.SkipLast(1).Last(), 50);
+            shortEdges = new List<Line>();
+            shortEdgeIndices = new List<int>();
+            for (int i = 0; i < perimeterSegments.Count(); i++)
+            {
+                var start = perimeterAngles[i];
+                var end = perimeterAngles[(i + 1) % perimeterAngles.Count];
+                if (start > 80 && start < 100 && end > 80 && end < 100 && perimeterSegments[i].Length() < longLength)
+                {
+                    shortEdges.Add(perimeterSegments[i]);
+                    shortEdgeIndices.Add(i);
+                }
+            }
+        }
+
+        private static void GenerateEndZones(SpacePlanningZonesInputs input, double corridorWidth, LevelVolume lvl, List<Profile> corridorProfiles, Line[] perimeterSegments, List<Line> shortEdges, List<(Polygon hull, Line centerLine)> singleLoadedZones, out List<Polygon> thickenedEndsOut, out List<Profile> thickerOffsetProfiles, out IEnumerable<Polygon> innerOffsetMinusThickenedEnds, out IEnumerable<Polygon> exclusionRegions)
+        {
+            // separate out short and long perimeter edges
+            var shortEdgesExtended = shortEdges.Select(l => new Line(l.Start - l.Direction() * 0.2, l.End + l.Direction() * 0.2));
+            var longEdges = perimeterSegments.Except(shortEdges);
+            var shortEdgeDepth = Math.Max(input.DepthAtEnds, input.OuterBandDepth);
+            var longEdgeDepth = input.OuterBandDepth;
+
+            var perimeterMinusSingleLoaded = new List<Profile>();
+            perimeterMinusSingleLoaded.AddRange(Profile.Difference(new[] { lvl.Profile }, singleLoadedZones.Select(p => new Profile(p.hull))));
+            var innerOffset = perimeterMinusSingleLoaded.SelectMany(p => p.Perimeter.Offset(-longEdgeDepth));
+            // calculate zones at rectangular "ends"
+            var thickenedEnds = shortEdgesExtended.SelectMany(s => s.ToPolyline(1).Offset(shortEdgeDepth, EndType.Butt)).ToList();
+            thickerOffsetProfiles = thickenedEnds.Select(o => new Profile(o.Offset(0.01))).ToList();
+
+            innerOffsetMinusThickenedEnds = innerOffset.SelectMany(i => Polygon.Difference(new[] { i }, thickenedEnds));
+            exclusionRegions = innerOffsetMinusThickenedEnds.SelectMany(r => r.Offset(2 * corridorWidth, EndType.Square));
+
+            var corridorInset = innerOffsetMinusThickenedEnds.Select(p => new Profile(p, p.Offset(-corridorWidth), Guid.NewGuid(), "Corridor"));
+            corridorProfiles.AddRange(corridorInset);
+            thickenedEndsOut = thickenedEnds;
+        }
+
+        private static void CorridorsFromCore(double corridorWidth, List<Profile> corridorProfiles, Profile levelBoundary, List<ServiceCore> coresInBoundary, IEnumerable<Polygon> innerOffsetMinusThickenedEnds, IEnumerable<Polygon> exclusionRegions)
+        {
+            var coreSegments = coresInBoundary.SelectMany(c => c.Profile.Perimeter.Offset((corridorWidth / 2) * 0.999).FirstOrDefault()?.Segments());
+
+            foreach (var enclosedRegion in innerOffsetMinusThickenedEnds)
+            {
+                foreach (var segment in coreSegments)
+                {
+                    enclosedRegion.Contains(segment.Start, out var startContainment);
+                    enclosedRegion.Contains(segment.End, out var endContainment);
+                    if (endContainment == Containment.Outside && startContainment == Containment.Outside)
+                    {
+                        continue;
+                    }
+                    var extendedSegment = segment.ExtendTo(new Profile(enclosedRegion));
+                    if (extendedSegment.Length() - segment.Length() < 2 * 8)
+                    {
+                        continue;
+                    }
+                    var thickenedCorridor = extendedSegment.ToPolyline(1).Offset(corridorWidth / 2.0, EndType.Butt);
+                    var difference = new List<Profile>();
+
+                    difference = Profile.Difference(corridorProfiles, exclusionRegions.Select(r => new Profile(r)));
+
+                    if (difference.Count > 0 && difference.Sum(d => d.Perimeter.Area()) > 10)
+                    {
+                        corridorProfiles.AddRange(Profile.Intersection(thickenedCorridor.Select(c => new Profile(c)), new[] { levelBoundary }));
+                    }
+                }
+            }
+        }
+
+        private static List<Element> SplitCornersAndGenerateSpaceBoundaries(List<Element> spaceBoundaries, SpacePlanningZonesInputs input, LevelVolume lvl, List<Profile> corridorProfiles, Profile levelBoundary, List<Profile> thickerOffsetProfiles = null)
+        {
+            var remainingSpaces = Profile.Difference(new[] { levelBoundary }, corridorProfiles);
+            foreach (var remainingSpace in remainingSpaces)
+            {
+                try
+                {
+                    if (remainingSpace.Perimeter.Vertices.Any(v => v.DistanceTo(levelBoundary.Perimeter) < 0.1))
+                    {
+                        var linearZones = thickerOffsetProfiles == null ? new List<Profile> { remainingSpace } : Profile.Difference(new[] { remainingSpace }, thickerOffsetProfiles);
+                        foreach (var linearZone in linearZones)
+                        {
+                            var segmentsExtended = new List<Polyline>();
+                            foreach (var line in linearZone.Segments())
+                            {
+                                if (line.Length() < 2) continue;
+                                var l = new Line(line.Start - line.Direction() * 0.1, line.End + line.Direction() * 0.1);
+                                var extended = l.ExtendTo(linearZone);
+                                var endDistance = extended.End.DistanceTo(l.End);
+                                var startDistance = extended.Start.DistanceTo(l.Start);
+                                var maxExtension = Math.Max(input.OuterBandDepth, input.DepthAtEnds) * 1.6;
+                                if (startDistance > 0.1 && startDistance < maxExtension)
+                                {
+                                    var startLine = new Line(extended.Start, line.Start);
+                                    segmentsExtended.Add(startLine.ToPolyline(1));
+                                }
+                                if (endDistance > 0.1 && endDistance < maxExtension)
+                                {
+                                    var endLine = new Line(extended.End, line.End);
+                                    segmentsExtended.Add(endLine.ToPolyline(1));
+                                }
+                            }
+                            // Console.WriteLine(JsonConvert.SerializeObject(linearZone.Perimeter));
+                            // Console.WriteLine(JsonConvert.SerializeObject(linearZone.Voids));
+                            // Console.WriteLine(JsonConvert.SerializeObject(segmentsExtended));
+                            var splits = Profile.Split(new[] { linearZone }, segmentsExtended, Vector3.EPSILON);
+                            spaceBoundaries.AddRange(splits.Select(s => SpaceBoundary.Make(s, input.DefaultProgramAssignment, lvl.Transform, lvl.Height)));
+                        }
+                        if (thickerOffsetProfiles != null)
+                        {
+                            var endCapZones = Profile.Intersection(new[] { remainingSpace }, thickerOffsetProfiles);
+                            spaceBoundaries.AddRange(endCapZones.Select(s => SpaceBoundary.Make(s, input.DefaultProgramAssignment, lvl.Transform, lvl.Height)));
+                        }
+                    }
+                    else
+                    {
+                        spaceBoundaries.Add(SpaceBoundary.Make(remainingSpace, input.DefaultProgramAssignment, lvl.Transform, lvl.Height));
+                    }
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine("🚨");
+                    Console.WriteLine(e.Message);
+                    Console.WriteLine(e.StackTrace);
+                    spaceBoundaries.Add(SpaceBoundary.Make(remainingSpace, input.DefaultProgramAssignment, lvl.Transform, lvl.Height));
+                }
+            }
+            return spaceBoundaries;
+        }
+
+        private static void ThickenAndExtendSingleLoaded(double corridorWidth, List<Profile> corridorProfiles, List<ServiceCore> coresInBoundary, List<Polygon> thickerOffsets, IEnumerable<Polygon> innerOffsetMinusThicker, (Polygon hull, Line centerLine)[] allCenterLines)
+        {
+            // thicken and extend single loaded
+            foreach (var singleLoadedZone in allCenterLines)
+            {
+                var cl = singleLoadedZone.centerLine;
+                List<Line> centerlines = new List<Line> { cl };
+                foreach (var core in coresInBoundary)
+                {
+                    List<Line> linesRunning = new List<Line>();
+                    foreach (var curve in centerlines)
+                    {
+                        curve.Trim(core.Profile.Perimeter, out var linesTrimmedByCore);
+                        linesRunning.AddRange(linesTrimmedByCore);
+                    }
+                    centerlines = linesRunning;
+                }
+                cl = centerlines.OrderBy(l => l.Length()).Last();
+                foreach (var clCandidate in centerlines)
+                {
+
+                    var extended = clCandidate.ExtendTo(innerOffsetMinusThicker.SelectMany(p => p.Segments())).ToPolyline(1);
+                    if (extended.Length() == cl.Length() && innerOffsetMinusThicker.Count() > 0)
+                    {
+                        var end = extended.End;
+                        var dist = double.MaxValue;
+                        Vector3? runningPt = null;
+                        foreach (var boundary in innerOffsetMinusThicker)
+                        {
+                            var closestDist = end.DistanceTo(boundary, out var pt);
+                            if (closestDist < dist)
+                            {
+                                dist = closestDist;
+                                runningPt = pt;
+                            }
+                        }
+                        extended = new Polyline(new[] { extended.Start, extended.End, runningPt.Value });
+                    }
+                    //TODO - verify that newly constructed line is contained within building perimeter
+                    var thickenedCorridor = extended.Offset(corridorWidth / 2.0, EndType.Square);
+                    corridorProfiles.AddRange(Profile.Difference(thickenedCorridor.Select(c => new Profile(c)), thickerOffsets.Select(c => new Profile(c))));
+                }
+
+            }
+        }
+
+        private static (Polygon hull, Line centerLine)[] JoinSingleLoaded(List<(Polygon hull, Line centerLine)> singleLoadedZones)
+        {
+            // join single loaded zones to each other (useful in bent-bar case)
+            var allCenterLines = singleLoadedZones.ToArray();
+            var distanceThreshold = 10.0;
+            for (int i = 0; i < allCenterLines.Count(); i++)
+            {
+                var crvA = allCenterLines[i].centerLine;
+                for (int j = 0; j < i; j++)
+                {
+                    var crvB = allCenterLines[j].centerLine;
+                    var doesIntersect = crvA.Intersects(crvB, out var intersection, true, true);
+                    // Console.WriteLine($"DOES INTERSECT: " + doesIntersect.ToString());
+
+                    var nearPtA = intersection.ClosestPointOn(crvA);
+                    var nearPtB = intersection.ClosestPointOn(crvB);
+                    if (nearPtA.DistanceTo(intersection) + nearPtB.DistanceTo(intersection) < distanceThreshold)
+                    {
+                        if (nearPtA.DistanceTo(crvA.Start) < 0.01)
+                        {
+                            allCenterLines[i] = (allCenterLines[i].hull, new Line(intersection, crvA.End));
+                        }
+                        else
+                        {
+                            allCenterLines[i] = (allCenterLines[i].hull, new Line(crvA.Start, intersection));
+                        }
+                        if (nearPtB.DistanceTo(crvB.Start) < 0.01)
+                        {
+                            allCenterLines[j] = (allCenterLines[j].hull, new Line(intersection, crvB.End));
+                        }
+                        else
+                        {
+                            allCenterLines[j] = (allCenterLines[j].hull, new Line(crvB.Start, intersection));
+                        }
+                    }
+
+                }
+            }
+
+            return allCenterLines;
+        }
+
+        private static List<(Polygon hull, Line centerLine)> CalculateSingleLoadedZones(SpacePlanningZonesInputs input, double corridorWidth, Line[] perimeterSegments, List<int> shortEdgeIndices)
+        {
+            var singleLoadedZones = new List<(Polygon hull, Line centerLine)>();
+            var singleLoadedLengthThreshold = input.OuterBandDepth * 2 + corridorWidth * 2 + 5; // (two offsets, two corridors, and a usable space width)
+            foreach (var sei in shortEdgeIndices)
+            {
+                var ps = perimeterSegments;
+                if (ps[sei].Length() < singleLoadedLengthThreshold)
+                {
+                    var legSegments = new[] {
+                            ps[(sei + ps.Length -1) % ps.Length],
+                            ps[sei],
+                            ps[(sei + 1) % ps.Length]
+                        };
+                    var legLength = Math.Min(legSegments[0].Length(), legSegments[2].Length());
+                    legSegments[0] = new Line(ps[sei].Start, ps[sei].Start + legLength * (legSegments[0].Direction() * -1));
+                    legSegments[2] = new Line(ps[sei].End, ps[sei].End + legLength * (legSegments[2].Direction()));
+                    var hull = ConvexHull.FromPolylines(legSegments.Select(l => l.ToPolyline(1)));
+                    var centerLine = new Line((legSegments[0].Start + legSegments[2].Start) / 2, (legSegments[0].End + legSegments[2].End) / 2);
+
+                    singleLoadedZones.Add((hull, centerLine));
+                }
+
+            }
+
+            return singleLoadedZones;
         }
 
         private static void SplitZones(SpacePlanningZonesInputs input, double corridorWidth, LevelVolume lvl, List<Element> spaceBoundaries, List<Profile> corridorProfiles, Vector3 pt, bool addCorridor = true)

--- a/ZonePlanningFunctions/SpacePlanningZones/src/SpacePlanningZonesInputs.g.cs
+++ b/ZonePlanningFunctions/SpacePlanningZones/src/SpacePlanningZonesInputs.g.cs
@@ -21,6 +21,54 @@ namespace SpacePlanningZones
 {
     #pragma warning disable // Disable all warnings
 
+    /// <summary>A polyline that has been thickened into a polygon.</summary>
+    [Newtonsoft.Json.JsonConverter(typeof(Elements.Serialization.JSON.JsonInheritanceConverter), "discriminator")]
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.21.0 (Newtonsoft.Json v12.0.0.0)")]
+    
+    public partial class ThickenedPolyline 
+    
+    {
+        [Newtonsoft.Json.JsonConstructor]
+        public ThickenedPolyline(Polyline @polyline, double @width, bool @flip, double @leftWidth, double @rightWidth)
+        {
+            var validator = Validator.Instance.GetFirstValidatorForType<ThickenedPolyline>();
+            if(validator != null)
+            {
+                validator.PreConstruct(new object[]{ @polyline, @width, @flip, @leftWidth, @rightWidth});
+            }
+        
+            this.Polyline = @polyline;
+            this.Width = @width;
+            this.Flip = @flip;
+            this.LeftWidth = @leftWidth;
+            this.RightWidth = @rightWidth;
+        
+            if(validator != null)
+            {
+                validator.PostConstruct(this);
+            }
+        }
+    
+        [Newtonsoft.Json.JsonProperty("polyline", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public Polyline Polyline { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("width", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double Width { get; set; }
+    
+        [Newtonsoft.Json.JsonProperty("flip", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public bool Flip { get; set; }
+    
+        /// <summary>The amount to thicken the polyline on its "left" side, imagining that the polyline is extending away from you. That is, if the polyline starts at (0,0,0) and follows the +Z axis, the left side extends into the -X quadrant.</summary>
+        [Newtonsoft.Json.JsonProperty("leftWidth", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double LeftWidth { get; set; }
+    
+        /// <summary>The amount to thicken the polyline on its "right" side, imagining that the polyline is extending away from you. That is, if the polyline starts at (0,0,0) and follows the +Z axis, the right side extends into the +X quadrant.</summary>
+        [Newtonsoft.Json.JsonProperty("rightWidth", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double RightWidth { get; set; }
+    
+    
+    }
+    
     [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.21.0 (Newtonsoft.Json v12.0.0.0)")]
     
     public  class SpacePlanningZonesInputs : S3Args
@@ -28,16 +76,18 @@ namespace SpacePlanningZones
     {
         [Newtonsoft.Json.JsonConstructor]
         
-        public SpacePlanningZonesInputs(string @defaultProgramAssignment, double @corridorWidth, double @outerBandDepth, double @depthAtEnds, IList<Vector3> @additionalCorridorLocations, IList<Vector3> @manualSplitLocations, Overrides @overrides, string bucketName, string uploadsBucket, Dictionary<string, string> modelInputKeys, string gltfKey, string elementsKey, string ifcKey):
+        public SpacePlanningZonesInputs(string @defaultProgramAssignment, SpacePlanningZonesInputsCirculationMode @circulationMode, IList<ThickenedPolyline> @corridors, double @corridorWidth, double @outerBandDepth, double @depthAtEnds, IList<Vector3> @additionalCorridorLocations, IList<Vector3> @manualSplitLocations, Overrides @overrides, string bucketName, string uploadsBucket, Dictionary<string, string> modelInputKeys, string gltfKey, string elementsKey, string ifcKey):
         base(bucketName, uploadsBucket, modelInputKeys, gltfKey, elementsKey, ifcKey)
         {
             var validator = Validator.Instance.GetFirstValidatorForType<SpacePlanningZonesInputs>();
             if(validator != null)
             {
-                validator.PreConstruct(new object[]{ @defaultProgramAssignment, @corridorWidth, @outerBandDepth, @depthAtEnds, @additionalCorridorLocations, @manualSplitLocations, @overrides});
+                validator.PreConstruct(new object[]{ @defaultProgramAssignment, @circulationMode, @corridors, @corridorWidth, @outerBandDepth, @depthAtEnds, @additionalCorridorLocations, @manualSplitLocations, @overrides});
             }
         
             this.DefaultProgramAssignment = @defaultProgramAssignment;
+            this.CirculationMode = @circulationMode;
+            this.Corridors = @corridors;
             this.CorridorWidth = @corridorWidth;
             this.OuterBandDepth = @outerBandDepth;
             this.DepthAtEnds = @depthAtEnds;
@@ -54,6 +104,17 @@ namespace SpacePlanningZones
         /// <summary>What would you like the default program for all zones to be? This program type will be assigned to all spaces, and then you can pick specific programs for individual spaces with the Edit Program Assignments button.</summary>
         [Newtonsoft.Json.JsonProperty("Default Program Assignment", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string DefaultProgramAssignment { get; set; } = "unspecified";
+    
+        /// <summary>How should circulation be calculated? 
+        /// Automatic: a typical circulation network will be generated for you. 
+        /// Manual: you draw the circulation paths yourself.</summary>
+        [Newtonsoft.Json.JsonProperty("Circulation Mode", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public SpacePlanningZonesInputsCirculationMode CirculationMode { get; set; } = SpacePlanningZonesInputsCirculationMode.Automatic;
+    
+        /// <summary>Define the circulation network by drawing one or more corridor paths.</summary>
+        [Newtonsoft.Json.JsonProperty("Corridors", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<ThickenedPolyline> Corridors { get; set; }
     
         /// <summary>How wide should circulation paths be?</summary>
         [Newtonsoft.Json.JsonProperty("Corridor Width", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -81,6 +142,17 @@ namespace SpacePlanningZones
         [Newtonsoft.Json.JsonProperty("overrides", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public Overrides Overrides { get; set; }
     
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.21.0 (Newtonsoft.Json v12.0.0.0)")]
+    public enum SpacePlanningZonesInputsCirculationMode
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"Automatic")]
+        Automatic = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"Manual")]
+        Manual = 1,
     
     }
     


### PR DESCRIPTION
- This looks like a huge PR, but it's mostly just lots of refactoring (it's still a bit of a mess)
- enable an option to provide manually drawn circulation instead of automatically drawn

TESTING
- verified that generates reasonable results with manually drawn circulation
- verified that results are unchanged with automatic circulation

COMMENTS
- Won't publish function until https://github.com/hypar-io/Explore/pull/1237 is merged, to ensure new inputs get correct default values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/hyparspace/3)
<!-- Reviewable:end -->
