### PR TITLE
bring open office layout up to date

### DIFF
--- a/LayoutFunctions/OpenOfficeLayout/dependencies/LevelElements.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/LevelElements.g.cs
@@ -29,19 +29,8 @@ namespace Elements
         public LevelElements(IList<Element> @elements, System.Guid @id = default, string @name = null)
             : base(id, name)
         {
-            var validator = Validator.Instance.GetFirstValidatorForType<LevelElements>();
-            if(validator != null)
-            {
-                validator.PreConstruct(new object[]{ @elements, @id, @name});
-            }
-        
             this.Elements = @elements;
-            
-            if(validator != null)
-            {
-                validator.PostConstruct(this);
             }
-        }
     
         /// <summary>The list of elements.</summary>
         [Newtonsoft.Json.JsonProperty("Elements", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]

--- a/LayoutFunctions/OpenOfficeLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/LevelVolume.g.cs
@@ -26,24 +26,14 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [Newtonsoft.Json.JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
-            var validator = Validator.Instance.GetFirstValidatorForType<LevelVolume>();
-            if(validator != null)
-            {
-                validator.PreConstruct(new object[]{ @profile, @height, @area, @transform, @material, @representation, @isElementDefinition, @id, @name});
-            }
-        
             this.Profile = @profile;
             this.Height = @height;
             this.Area = @area;
-            
-            if(validator != null)
-            {
-                validator.PostConstruct(this);
+            this.BuildingName = @buildingName;
             }
-        }
     
         /// <summary>The profile of the level Volume</summary>
         [Newtonsoft.Json.JsonProperty("Profile", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -56,6 +46,10 @@ namespace Elements
         /// <summary>The area of the level's profile.</summary>
         [Newtonsoft.Json.JsonProperty("Area", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Area { get; set; }
+    
+        /// <summary>The name of the building or mass this level belongs to (optional)</summary>
+        [Newtonsoft.Json.JsonProperty("Building Name", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string BuildingName { get; set; }
     
     
     }

--- a/LayoutFunctions/OpenOfficeLayout/dependencies/OpenOfficeLayout.Dependencies.csproj
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/OpenOfficeLayout.Dependencies.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <Compile Include="../../../ZonePlanningFunctions/SpacePlanningZones/dependencies/SpaceBoundary.cs" />
     <Compile Include="../../../ZonePlanningFunctions/SpacePlanningZones/dependencies/ProgramRequirement.g.cs" />
+    <Compile Include="../../../ZonePlanningFunctions/SpacePlanningZones/dependencies/ProgramRequirementCountType.g.cs" />
     <Compile Include="../../../ZonePlanningFunctions/SpacePlanningZones/dependencies/ProgramRequirement.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/LayoutFunctions/OpenOfficeLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/SpaceBoundary.g.cs
@@ -26,24 +26,15 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [Newtonsoft.Json.JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
-            var validator = Validator.Instance.GetFirstValidatorForType<SpaceBoundary>();
-            if(validator != null)
-            {
-                validator.PreConstruct(new object[]{ @boundary, @cells, @area, @transform, @material, @representation, @isElementDefinition, @id, @name});
-            }
-        
             this.Boundary = @boundary;
             this.Cells = @cells;
             this.Area = @area;
-            
-            if(validator != null)
-            {
-                validator.PostConstruct(this);
+            this.Length = @length;
+            this.Depth = @depth;
             }
-        }
     
         /// <summary>The boundary of the space</summary>
         [Newtonsoft.Json.JsonProperty("Boundary", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
@@ -56,6 +47,14 @@ namespace Elements
         /// <summary>The area of the boundary</summary>
         [Newtonsoft.Json.JsonProperty("Area", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double Area { get; set; }
+    
+        /// <summary>The rough length of this space boundary, parallel to the accessible edge</summary>
+        [Newtonsoft.Json.JsonProperty("Length", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double? Length { get; set; }
+    
+        /// <summary>The rough depth of the space boundary, perpendicular to the accessible edge</summary>
+        [Newtonsoft.Json.JsonProperty("Depth", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double? Depth { get; set; }
     
     
     }

--- a/LayoutFunctions/OpenOfficeLayout/dependencies/WorkpointCount.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/WorkpointCount.g.cs
@@ -26,26 +26,20 @@ namespace Elements
     public partial class WorkpointCount : Element
     {
         [Newtonsoft.Json.JsonConstructor]
-        public WorkpointCount(int @count, System.Guid @id = default, string @name = null)
+        public WorkpointCount(int @count, string @type, System.Guid @id = default, string @name = null)
             : base(id, name)
         {
-            var validator = Validator.Instance.GetFirstValidatorForType<WorkpointCount>();
-            if(validator != null)
-            {
-                validator.PreConstruct(new object[]{ @count, @id, @name});
-            }
-        
             this.Count = @count;
-            
-            if(validator != null)
-            {
-                validator.PostConstruct(this);
+            this.Type = @type;
             }
-        }
     
         /// <summary>The number of workpoints</summary>
         [Newtonsoft.Json.JsonProperty("Count", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int Count { get; set; }
+    
+        /// <summary>Type of the workpoint</summary>
+        [Newtonsoft.Json.JsonProperty("Type", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string Type { get; set; }
     
     
     }

--- a/LayoutFunctions/OpenOfficeLayout/src/FurnitureLocationsOverride.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/src/FurnitureLocationsOverride.g.cs
@@ -1,0 +1,29 @@
+using Elements;
+using System.Collections.Generic;
+
+namespace OpenOfficeLayout
+{
+	/// <summary>
+	/// Override metadata for FurnitureLocationsOverride
+	/// </summary>
+	public partial class FurnitureLocationsOverride : IOverride
+	{
+        public static string Name = "Furniture Locations";
+        public static string Dependency = null;
+        public static string Context = "[*discriminator=Elements.ElementInstance]";
+		public static string Paradigm = "Edit";
+
+        /// <summary>
+        /// Get the override name for this override.
+        /// </summary>
+        public string GetName() {
+			return Name;
+		}
+
+		public object GetIdentity() {
+
+			return Identity;
+		}
+
+	}
+}

--- a/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayout.cs
+++ b/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayout.cs
@@ -63,7 +63,7 @@ namespace OpenOfficeLayout
                 foreach (var ob in officeBoundaries)
                 {
                     // create a boundary we can use to override individual groups of desks. It's sunk slightly so that, if floors are on, you don't see it. 
-                    var overridableBoundary = new SpaceBoundary(ob.Boundary, ob.Cells, ob.Area, ob.Transform.Concatenated(new Transform(0, 0, -0.05)), ob.Material, new Representation(new[] { new Lamina(ob.Boundary.Perimeter, false) }), false, Guid.NewGuid(), "DeskArea");
+                    var overridableBoundary = new SpaceBoundary(ob.Boundary, ob.Cells, ob.Area, null, null, ob.Transform.Concatenated(new Transform(0, 0, -0.05)), ob.Material, new Representation(new[] { new Lamina(ob.Boundary.Perimeter, false) }), false, Guid.NewGuid(), "DeskArea");
                     overridableBoundary.ParentCentroid = ob.ParentCentroid;
                     overridableBoundary.AdditionalProperties.Add("Desk Type", Hypar.Model.Utilities.GetStringValueFromEnum(input.DeskType));
                     overridableBoundary.AdditionalProperties.Add("Integrated Collaboration Space Density", input.IntegratedCollaborationSpaceDensity);
@@ -223,7 +223,8 @@ namespace OpenOfficeLayout
 
             OverrideUtilities.InstancePositionOverrides(input.Overrides, output.Model);
             var model = output.Model;
-            model.AddElement(new WorkpointCount(deskCount, Guid.NewGuid(), null));
+
+            model.AddElement(new WorkpointCount(deskCount, "Desk", Guid.NewGuid(), null));
             var outputWithData = new OpenOfficeLayoutOutputs(deskCount);
             outputWithData.Model = model;
 

--- a/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayoutOutputs.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayoutOutputs.g.cs
@@ -20,7 +20,7 @@ namespace OpenOfficeLayout
 		/// The number of desks.
 		/// </summary>
 		[JsonProperty("Total Desk Count")]
-		public double TotalDeskCount {get;}
+		public double TotalDeskCount {get; set;}
 
 
 

--- a/LayoutFunctions/OpenOfficeLayout/src/SpaceSettingsOverride.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/src/SpaceSettingsOverride.g.cs
@@ -1,0 +1,29 @@
+using Elements;
+using System.Collections.Generic;
+
+namespace OpenOfficeLayout
+{
+	/// <summary>
+	/// Override metadata for SpaceSettingsOverride
+	/// </summary>
+	public partial class SpaceSettingsOverride : IOverride
+	{
+        public static string Name = "Space Settings";
+        public static string Dependency = null;
+        public static string Context = "[*discriminator=Elements.SpaceBoundary&Name=DeskArea]";
+		public static string Paradigm = "Edit";
+
+        /// <summary>
+        /// Get the override name for this override.
+        /// </summary>
+        public string GetName() {
+			return Name;
+		}
+
+		public object GetIdentity() {
+
+			return Identity;
+		}
+
+	}
+}


### PR DESCRIPTION
Getting Open Office layout to a buildable state

NOTE: I marked the WorkpointCount `type` as "Desk" here — feel free to change this if you had something else in mind 