### PR TITLE
Fix circulation polyline when drawn outside of a plan view

### DIFF
--- a/ZonePlanningFunctions/Circulation/src/Circulation.cs
+++ b/ZonePlanningFunctions/Circulation/src/Circulation.cs
@@ -148,6 +148,8 @@ namespace Circulation
                 {
                     foreach (var addedCorridor in input.Overrides.Additions.Corridors)
                     {
+                        // If the added corridor has a level associated with it, but
+                        // that level doesn't match the one we're currently processing, ignore.
                         if (addedCorridor.Value?.Level != null && addedCorridor.Value.Level.Name != lvl.Name)
                         {
                             continue;
@@ -158,8 +160,13 @@ namespace Circulation
                         {
                             var p = OffsetOnSideAndUnionSafe(corridorPolyline, output);
                             corridorProfiles.Add(p);
-
-                            corridorPolyline.Polyline = corridorPolyline.Polyline.TransformedPolyline(lvl.Transform);
+                            // Corridors can be added from a plan view,
+                            // in which case they'll have a level, and we should 
+                            // set the polyline at the correct elevation.
+                            // Otherwise, we should set the polyline at z=0, 
+                            // and let the web UI handle displaying it at the correct elevation.
+                            var plTransform = addedCorridor.Value?.Level != null ? lvl.Transform : new Transform();
+                            corridorPolyline.Polyline = corridorPolyline.Polyline.TransformedPolyline(plTransform);
                             var segment = new CirculationSegment(p, 0.11)
                             {
                                 Material = CorridorMat,


### PR DESCRIPTION
@nadiia-volyk noticed that circulation segments were being drawn at the wrong elevation in some scenarios. This is what I found:

- Automatically-generated circulation had the correct elevation
- user-created circulation (via "Add Corridors" override) had: 
   - The correct elevation, if drawn while in an active plan view (via the "views" menu)
   - the incorrect elevation, if drawn outside of any active focus view. 

When a corridor is drawn outside an active view, it has no `Level` property assigned, and therefore gets drawn on all levels. When this was happening, all created segments were sharing the same `ThickenedPolyline` from the Add override. This is corrected by creating a new ThickenedPolyline for each segment at each level.

Known Issues:
- _deleting_ a CorridorSegment created outside a view will delete _all_ corridor segments created from the same polyline, but _editing_ that same segment will only apply to the selected one.  

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/hyparspace/25)
<!-- Reviewable:end -->
