### PR TITLE
Trim circulation segments to level boundary

### DIFF
--- a/ZonePlanningFunctions/Circulation/src/Circulation.cs
+++ b/ZonePlanningFunctions/Circulation/src/Circulation.cs
@@ -169,7 +169,7 @@ namespace Circulation
                                 corridorPolyline.LeftWidth,
                                 corridorPolyline.RightWidth
                              );
-                            var newCirculationSegments = CreateCirculationSegments(lvl, levelBoundary, corridorPolyline, p, modifiedCorridorPolyline.Polyline);
+                            var newCirculationSegments = CreateCirculationSegments(lvl, levelBoundary, modifiedCorridorPolyline, p, modifiedCorridorPolyline.Polyline, circulationSegments);
                             foreach (var circulationSegment in newCirculationSegments)
                             {
                                 corridorProfiles.Add(circulationSegment.Profile);

--- a/ZonePlanningFunctions/Circulation/src/Circulation.cs
+++ b/ZonePlanningFunctions/Circulation/src/Circulation.cs
@@ -169,7 +169,7 @@ namespace Circulation
                                 corridorPolyline.LeftWidth,
                                 corridorPolyline.RightWidth
                              );
-                            var newCirculationSegments = CreateCirculationSegments(lvl, levelBoundary, modifiedCorridorPolyline, p, modifiedCorridorPolyline.Polyline, circulationSegments);
+                            var newCirculationSegments = CreateCirculationSegments(lvl, levelBoundary, modifiedCorridorPolyline, p, modifiedCorridorPolyline.Polyline);
                             foreach (var circulationSegment in newCirculationSegments)
                             {
                                 corridorProfiles.Add(circulationSegment.Profile);

--- a/ZonePlanningFunctions/Circulation/src/Circulation.cs
+++ b/ZonePlanningFunctions/Circulation/src/Circulation.cs
@@ -174,7 +174,7 @@ namespace Circulation
                             {
                                 corridorProfiles.Add(circulationSegment.Profile);
                                 circulationSegments.Add(circulationSegment);
-                                Identity.AddOverrideIdentity(circulationSegment.Profile, addedCorridor);
+                                Identity.AddOverrideIdentity(circulationSegment, addedCorridor);
                             }
                         }
                         catch (Exception e)


### PR DESCRIPTION
Where a circulation segment extends beyond a floor or level boundary, the geometry is trimmed to the boundary

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/hyparspace/26)
<!-- Reviewable:end -->
