### PR TITLE
build-all.sh: signal error to github workflow if buid failed

### DIFF
--- a/build-all.sh
+++ b/build-all.sh
@@ -32,4 +32,5 @@ else
   for failed_directory in "${failed_directories[@]}"; do
     echo "$failed_directory"
   done
+  exit 1
 fi


### PR DESCRIPTION
github workflow is working well in the pull requests that were recently updated.
We can add fail condition now in case build fails

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/48)
<!-- Reviewable:end -->
