### PR TITLE
Datahall avoid columns

### DIFF
--- a/LayoutFunctions/DataHall/.vscode/launch.json
+++ b/LayoutFunctions/DataHall/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+  "version": "0.2.0",
+  "inputs": [
+    {
+      "id": "workflowId",
+      "type": "promptString",
+      "description": "Enter the workflow id to run."
+    }
+  ],
+  "configurations": [
+    {
+      "name": "Attach to Hypar Run",
+      "type": "coreclr",
+      "request": "attach",
+      "processName": "DataHallLayout.Server"
+    },
+    {
+      "name": "Launch Hypar Run (Run once only)",
+      "type": "coreclr",
+      "request": "launch",
+      "program": "${workspaceFolder}/server/bin/Debug/net6.0/DataHallLayout.Server.dll",
+      "args": [
+        "--workflow-id",
+        "${input:workflowId}"
+      ],
+      "preLaunchTask": "server-build"
+    }
+  ]
+}

--- a/LayoutFunctions/DataHall/.vscode/tasks.json
+++ b/LayoutFunctions/DataHall/.vscode/tasks.json
@@ -1,0 +1,15 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "server-build",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/server/DataHallLayout.Server.csproj"
+      ],
+      "problemMatcher": "$msCompile"
+    }
+  ]
+}

--- a/LayoutFunctions/DataHall/dependencies/DataHallLayout.Dependencies.csproj
+++ b/LayoutFunctions/DataHall/dependencies/DataHallLayout.Dependencies.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="21.21.21" />
+    <PackageReference Include="Hypar.Elements" Version="2.0.0" />
     <PackageReference Include="Hypar.Functions" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/LayoutFunctions/DataHall/dependencies/DataHallLayout.Dependencies.csproj
+++ b/LayoutFunctions/DataHall/dependencies/DataHallLayout.Dependencies.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="2.0.0" />
-    <PackageReference Include="Hypar.Functions" Version="1.6.0" />
+    <PackageReference Include="Hypar.Elements" Version="21.21.21" />
+    <PackageReference Include="Hypar.Functions" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/LayoutFunctions/DataHall/hypar.json
+++ b/LayoutFunctions/DataHall/hypar.json
@@ -10,6 +10,11 @@
       "autohide": false,
       "name": "Space Planning Zones",
       "optional": false
+    },
+    {
+      "autohide": false,
+      "name": "Columns",
+      "optional": true
     }
   ],
   "input_schema": {

--- a/LayoutFunctions/DataHall/server/DataHallLayout.Server.csproj
+++ b/LayoutFunctions/DataHall/server/DataHallLayout.Server.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\DataHallLayout.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hypar.Server" Version="1.8.0" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/LayoutFunctions/DataHall/server/Program.cs
+++ b/LayoutFunctions/DataHall/server/Program.cs
@@ -1,0 +1,26 @@
+
+using System;
+using System.IO;
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace Hypar.Server
+{
+    public class Program
+    {
+        public static async Task Main(string[] args)
+        {
+            await HyparServer.StartAsync(
+                args,
+                Path.GetFullPath(Path.Combine(Assembly.GetExecutingAssembly().Location, "../../../../..")),
+                async (executionRequest) =>
+                {
+                    var input = executionRequest.Args.ToObject<DataHallLayout.DataHallLayoutInputs>();
+                    var function = new DataHallLayout.Function();
+                    Directory.SetCurrentDirectory(Path.GetDirectoryName(typeof(DataHallLayout.Function).Assembly.Location)!);
+                    return await function.Handler(input, null);
+                });
+        }
+    }
+}

--- a/LayoutFunctions/DataHall/src/DataHallLayout.cs
+++ b/LayoutFunctions/DataHall/src/DataHallLayout.cs
@@ -153,16 +153,9 @@ namespace DataHallLayout
             }
 
             var allColumns = inputModels["Columns"].Elements.Values.OfType<Column>().ToList();
-            List<Column> columns = new List<Column>();
-
-            foreach (Column column in allColumns)
-            {
-                bool columnIn = column.Profile.Perimeter.Vertices.All(point => room.Boundary.Contains(point + column.Location));
-                if (columnIn)
-                {
-                    columns.Add(column);
-                }
-            }
+            var columns = allColumns
+                .Where(column => column.Profile.Perimeter.Vertices.All(point => room.Boundary.Contains(point + column.Location)))
+                .ToList();
 
             return columns.Count > 0 ? columns : null;
         }

--- a/LayoutFunctions/DataHall/src/DataHallLayout.cs
+++ b/LayoutFunctions/DataHall/src/DataHallLayout.cs
@@ -139,7 +139,7 @@ namespace DataHallLayout
             var rackCount = model.AllElementsOfType<ElementInstance>().Count();
             var areaInSf = totalArea * 10.7639;
             var density = input.KWRack * rackCount / areaInSf;
-            var output = new DataHallDummyOutputs(rackCount, $"{density * 1000:0} watts/sf");
+            var output = new DataHallLayoutOutputs(rackCount, $"{density * 1000:0} watts/sf");
             output.Model = model;
             output.Warnings.AddRange(warnings);
             return output;

--- a/LayoutFunctions/DataHall/src/DataHallLayout.cs
+++ b/LayoutFunctions/DataHall/src/DataHallLayout.cs
@@ -109,7 +109,7 @@ namespace DataHallLayout
                     var cellRect = cell.GetCellGeometry() as Polygon;
                     bool intersectsColumn = CheckIntersectsWithColumns(cellRect, roomColumns);
 
-                    if (cell.IsTrimmed() || cell.Type == null || cell.GetTrimmedCellGeometry().Count() == 0 || intersectsColumn)
+                    if (cell.IsTrimmed() || cell.Type == null || cell.GetTrimmedCellGeometry().Count() == 0)
                     {
                         continue;
                     }
@@ -121,13 +121,13 @@ namespace DataHallLayout
                     {
                         model.AddElement(new Panel(cellRect, BuiltInMaterials.ZAxis, room.Transform));
                     }
-                    else if (cell.Type == "Forward Rack" && cellRect.Area().ApproximatelyEquals(width * depth, 0.01))
+                    else if (cell.Type == "Forward Rack" && cellRect.Area().ApproximatelyEquals(width * depth, 0.01) && !intersectsColumn)
                     {
                         var centroid = cellRect.Centroid();
                         var rackInstance = dataRack.CreateInstance(alignment.Concatenated(new Transform(new Vector3(), rackAngle - 180)).Concatenated(new Transform(centroid)).Concatenated(room.Transform), "Rack");
                         model.AddElement(rackInstance);
                     }
-                    else if (cell.Type == "Backward Rack" && cellRect.Area().ApproximatelyEquals(width * depth, 0.01))
+                    else if (cell.Type == "Backward Rack" && cellRect.Area().ApproximatelyEquals(width * depth, 0.01) && !intersectsColumn)
                     {
                         var centroid = cellRect.Centroid();
                         var rackInstance = dataRack.CreateInstance(alignment.Concatenated(new Transform(new Vector3(), rackAngle)).Concatenated(new Transform(centroid)).Concatenated(room.Transform), "Rack");

--- a/LayoutFunctions/DataHall/src/Function.g.cs
+++ b/LayoutFunctions/DataHall/src/Function.g.cs
@@ -62,7 +62,14 @@ namespace DataHallLayout
 
             if(this.store == null)
             { 
-                this.store = new S3ModelStore<DataHallLayoutInputs>(RegionEndpoint.GetBySystemName("us-west-1"));
+                if (args.SignedResourceUrls == null)
+                {
+                    this.store = new S3ModelStore<DataHallLayoutInputs>(RegionEndpoint.GetBySystemName("us-west-1"));
+                }
+                else
+                {
+                    this.store = new UrlModelStore<DataHallLayoutInputs>();
+                }
             }
 
             var l = new InvocationWrapper<DataHallLayoutInputs,DataHallLayoutOutputs> (store, DataHallLayout.Execute);


### PR DESCRIPTION
This PR updates the Data Hall Layout function by adding some column avoidance logic. At this stage a rack will simply not be placed where it would intersect with a column. This adds 2 new functions `GetColumnsInRoom` and `CheckIntersectsWithColumn`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/61)
<!-- Reviewable:end -->
