### PR TITLE
add support for wall types

### DIFF
--- a/LayoutFunctions/ClassroomLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/ClassroomLayout/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/LayoutFunctions/ClassroomLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/ClassroomLayout/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/ClassroomLayout/hypar.json
+++ b/LayoutFunctions/ClassroomLayout/hypar.json
@@ -33,6 +33,7 @@
   ],
   "input_schema": {
     "type": "object",
+    "$hyparDeprecated": true,
     "properties": {
       "Create Walls": {
         "type": "boolean",

--- a/LayoutFunctions/DataHall/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/DataHall/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/InteriorPartitions/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/InteriorPartitions/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/LayoutFunctionCommon/ISpaceBoundary.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/ISpaceBoundary.cs
@@ -6,7 +6,7 @@ using Newtonsoft.Json;
 
 namespace Elements
 {
-    public interface ISpaceBoundary 
+    public interface ISpaceBoundary
     {
         string Name { get; set; }
         Profile Boundary { get; set; }
@@ -18,6 +18,8 @@ namespace Elements
 
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+
+        public string DefaultWallType { get; set; }
 
     }
 

--- a/LayoutFunctions/LayoutFunctionCommon/RoomEdge.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/RoomEdge.cs
@@ -61,6 +61,8 @@ public class RoomEdge
 
     public double Length => Line.Length();
     public Vector3 Direction => Line.Direction();
+
+    public bool? PrimaryEntryEdge { get; set; }
 }
 
 public static class RoomEdgeExtensions

--- a/LayoutFunctions/LayoutFunctionCommon/WallGeneration.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/WallGeneration.cs
@@ -35,7 +35,7 @@ namespace LayoutFunctionCommon
                 Line = s.TransformedLine(room.Transform),
                 Thickness = thicknesses?.ElementAtOrDefault(i)
             }), corridorSegments, levelProfile, out var wallCandidates);
-            orientationGuideEdge.Type = "Glass";
+            orientationGuideEdge.Type = room.DefaultWallType ?? "Glass";
             wallCandidateLines.Add(orientationGuideEdge);
             if (levelProfile != null)
             {
@@ -74,7 +74,7 @@ namespace LayoutFunctionCommon
             var orientationGuideEdges = SortEdgesByPrimaryAccess(allSegments, corridorSegments, levelProfile, 0.3);
             foreach (var orientationGuideEdge in orientationGuideEdges)
             {
-                orientationGuideEdge.Line.Type = "Glass";
+                orientationGuideEdge.Line.Type = room.DefaultWallType ?? "Glass";
                 var wallCandidateLines = new List<RoomEdge>
                 {
                     orientationGuideEdge.Line
@@ -539,7 +539,7 @@ namespace LayoutFunctionCommon
             }).ToList();
         }
 
-        public static List<RoomEdge> PartitionsAndGlazingCandidatesFromGrid(List<RoomEdge> wallCandidateLines, Grid2d grid, Profile levelBoundary)
+        public static List<RoomEdge> PartitionsAndGlazingCandidatesFromGrid(List<RoomEdge> wallCandidateLines, Grid2d grid, ISpaceBoundary room)
         {
             var wallCandidatesOut = new List<RoomEdge>();
             try
@@ -586,7 +586,7 @@ namespace LayoutFunctionCommon
                     var glassSegment = FindEdgeAdjacentToSegments(segments, glassLines, out var otherEdges);
                     if (glassSegment != null)
                     {
-                        glassSegment.Type = "Glass";
+                        glassSegment.Type = room.DefaultWallType ?? "Glass";
                         wallCandidatesOut.Add(glassSegment);
                     }
                 }

--- a/LayoutFunctions/LayoutFunctionCommon/WallGeneration.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/WallGeneration.cs
@@ -36,6 +36,7 @@ namespace LayoutFunctionCommon
                 Thickness = thicknesses?.ElementAtOrDefault(i)
             }), corridorSegments, levelProfile, out var wallCandidates);
             orientationGuideEdge.Type = room.DefaultWallType ?? "Glass";
+            orientationGuideEdge.PrimaryEntryEdge = true;
             wallCandidateLines.Add(orientationGuideEdge);
             if (levelProfile != null)
             {
@@ -75,6 +76,7 @@ namespace LayoutFunctionCommon
             foreach (var orientationGuideEdge in orientationGuideEdges)
             {
                 orientationGuideEdge.Line.Type = room.DefaultWallType ?? "Glass";
+                orientationGuideEdge.Line.PrimaryEntryEdge = true;
                 var wallCandidateLines = new List<RoomEdge>
                 {
                     orientationGuideEdge.Line
@@ -583,11 +585,12 @@ namespace LayoutFunctionCommon
                 if (trimmedGeo.Count() > 0)
                 {
                     var segments = trimmedGeo.OfType<Polygon>().SelectMany(g => g.Segments()).Select(GetRoomEdgeFromLine);
-                    var glassSegment = FindEdgeAdjacentToSegments(segments, glassLines, out var otherEdges);
-                    if (glassSegment != null)
+                    var entrySegment = FindEdgeAdjacentToSegments(segments, glassLines, out var otherEdges);
+                    if (entrySegment != null)
                     {
-                        glassSegment.Type = room.DefaultWallType ?? "Glass";
-                        wallCandidatesOut.Add(glassSegment);
+                        entrySegment.Type = room.DefaultWallType ?? "Glass";
+                        entrySegment.PrimaryEntryEdge = true;
+                        wallCandidatesOut.Add(entrySegment);
                     }
                 }
             }

--- a/LayoutFunctions/LoungeLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/LoungeLayout/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/LayoutFunctions/LoungeLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/LoungeLayout/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/MeetingRoomLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/MeetingRoomLayout/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/LayoutFunctions/MeetingRoomLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/MeetingRoomLayout/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/OpenCollabLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/OpenCollabLayout/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/LayoutFunctions/OpenCollabLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/OpenCollabLayout/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/OpenOfficeLayout/dependencies/CollaborationSpaceBoundary.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/CollaborationSpaceBoundary.g.cs
@@ -27,8 +27,8 @@ namespace Elements
     public partial class CollaborationSpaceBoundary : SpaceBoundary
     {
         [JsonConstructor]
-        public CollaborationSpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform, Material @material, Representation @representation, bool @isElementDefinition, System.Guid @id, string @name)
-            : base(boundary, cells, area, length, depth, height, programGroup, programType, programRequirement, level, levelLayout, hyparSpaceType, transform, material, representation, isElementDefinition, id, name)
+        public CollaborationSpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform, Material @material, Representation @representation, bool @isElementDefinition, System.Guid @id, string @name)
+            : base(boundary, cells, area, length, depth, height, programGroup, programType, programRequirement, level, levelLayout, hyparSpaceType, defaultWallType, transform, material, representation, isElementDefinition, id, name)
         {
             }
         

--- a/LayoutFunctions/OpenOfficeLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/LayoutFunctions/OpenOfficeLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/PantryLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/PantryLayout/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/LayoutFunctions/PantryLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/PantryLayout/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/PhoneBoothLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/PhoneBoothLayout/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/LayoutFunctions/PhoneBoothLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/PhoneBoothLayout/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/PhoneBoothLayout/hypar.json
+++ b/LayoutFunctions/PhoneBoothLayout/hypar.json
@@ -33,9 +33,9 @@
   ],
   "input_schema": {
     "type": "object",
-    "$hyparDeprecated": true,
     "properties": {
       "Create Walls": {
+        "$hyparDeprecated": true,
         "type": "boolean",
         "description": "Should partitions be added around phone booths?",
         "default": true

--- a/LayoutFunctions/PhoneBoothLayout/hypar.json
+++ b/LayoutFunctions/PhoneBoothLayout/hypar.json
@@ -33,6 +33,7 @@
   ],
   "input_schema": {
     "type": "object",
+    "$hyparDeprecated": true,
     "properties": {
       "Create Walls": {
         "type": "boolean",

--- a/LayoutFunctions/PhoneBoothLayout/src/PhoneBoothLayout.cs
+++ b/LayoutFunctions/PhoneBoothLayout/src/PhoneBoothLayout.cs
@@ -118,7 +118,7 @@ namespace PhoneBoothLayout
                         }
 
                     }
-                    wallCandidateLines.AddRange(WallGeneration.PartitionsAndGlazingCandidatesFromGrid(wallCandidateLines, grid, levelVolume?.Profile));
+                    wallCandidateLines.AddRange(WallGeneration.PartitionsAndGlazingCandidatesFromGrid(wallCandidateLines, grid, room));
 
                     totalBoothCount += seatsCount;
                     output.Model.AddElement(new SpaceMetric(room.Id, seatsCount, 0, 0, 0));

--- a/LayoutFunctions/PrivateOfficeLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/LayoutFunctions/PrivateOfficeLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/LayoutFunctions/PrivateOfficeLayout/hypar.json
+++ b/LayoutFunctions/PrivateOfficeLayout/hypar.json
@@ -60,6 +60,7 @@
                 }
             },
             "Create Walls": {
+                "$hyparDeprecated": true,
                 "type": "boolean",
                 "description": "Should partitions be added around offices?",
                 "default": true
@@ -121,6 +122,7 @@
                     }
                 },
                 "Create Walls": {
+                    "$hyparDeprecated": true,
                     "type": "boolean",
                     "description": "Should partitions be added around offices?",
                     "default": true

--- a/LayoutFunctions/PrivateOfficeLayout/src/PrivateOfficeLayout.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/src/PrivateOfficeLayout.cs
@@ -143,7 +143,7 @@ namespace PrivateOfficeLayout
 
                         if (config.Value.CreateWalls)
                         {
-                            wallCandidateLines.AddRange(WallGeneration.PartitionsAndGlazingCandidatesFromGrid(wallCandidateLines, grid, levelVolume?.Profile));
+                            wallCandidateLines.AddRange(WallGeneration.PartitionsAndGlazingCandidatesFromGrid(wallCandidateLines, grid, room));
                         }
                     }
 
@@ -231,7 +231,7 @@ namespace PrivateOfficeLayout
                         }
                         if (config.Value.CreateWalls)
                         {
-                            wallCandidateLines.AddRange(WallGeneration.PartitionsAndGlazingCandidatesFromGrid(wallCandidateLines, tempGrid, levelVolume?.Profile));
+                            wallCandidateLines.AddRange(WallGeneration.PartitionsAndGlazingCandidatesFromGrid(wallCandidateLines, tempGrid, room));
                         }
                         return returnCells;
                     }
@@ -240,7 +240,7 @@ namespace PrivateOfficeLayout
                         tempGrid.V.DivideByApproximateLength(config.Value.OfficeSizing.OfficeSize, EvenDivisionMode.RoundDown);
                         if (config.Value.CreateWalls)
                         {
-                            wallCandidateLines.AddRange(WallGeneration.PartitionsAndGlazingCandidatesFromGrid(wallCandidateLines, tempGrid, levelVolume?.Profile));
+                            wallCandidateLines.AddRange(WallGeneration.PartitionsAndGlazingCandidatesFromGrid(wallCandidateLines, tempGrid, room));
                         }
                         return tempGrid.GetCells().Select(c =>
                         {

--- a/LayoutFunctions/ReceptionLayout/dependencies/LevelVolume.g.cs
+++ b/LayoutFunctions/ReceptionLayout/dependencies/LevelVolume.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class LevelVolume : GeometricElement
     {
         [JsonConstructor]
-        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public LevelVolume(Profile @profile, double @height, double @area, string @buildingName, System.Guid? @level, System.Guid? @mass, System.Guid? @planView, IList<Profile> @profiles, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Profile = @profile;
@@ -37,6 +37,7 @@ namespace Elements
             this.Level = @level;
             this.Mass = @mass;
             this.PlanView = @planView;
+            this.Profiles = @profiles;
             }
         
         
@@ -73,6 +74,10 @@ namespace Elements
         /// <summary>The default plan view for this level</summary>
         [JsonProperty("Plan View", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public System.Guid? PlanView { get; set; }
+    
+        /// <summary>Multiple profiles used for a collection of volumes</summary>
+        [JsonProperty("Profiles", Required = Newtonsoft.Json.Required.DisallowNull, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public IList<Profile> Profiles { get; set; }
     
     
     }

--- a/LayoutFunctions/ReceptionLayout/dependencies/SpaceBoundary.g.cs
+++ b/LayoutFunctions/ReceptionLayout/dependencies/SpaceBoundary.g.cs
@@ -27,7 +27,7 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement
     {
         [JsonConstructor]
-        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
+        public SpaceBoundary(Profile @boundary, IList<Polygon> @cells, double @area, double? @length, double? @depth, double @height, string @programGroup, string @programType, System.Guid? @programRequirement, System.Guid? @level, System.Guid? @levelLayout, string @hyparSpaceType, string @defaultWallType, Transform @transform = null, Material @material = null, Representation @representation = null, bool @isElementDefinition = false, System.Guid @id = default, string @name = null)
             : base(transform, material, representation, isElementDefinition, id, name)
         {
             this.Boundary = @boundary;
@@ -42,6 +42,7 @@ namespace Elements
             this.Level = @level;
             this.LevelLayout = @levelLayout;
             this.HyparSpaceType = @hyparSpaceType;
+            this.DefaultWallType = @defaultWallType;
             }
         
         
@@ -96,6 +97,10 @@ namespace Elements
         /// <summary>The hypar-recognized space type name which will be used to determine which layout function to apply. In older space boundaries, this may not be set — fall back to the Name property for this purpose if not provided.</summary>
         [JsonProperty("Hypar Space Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public string HyparSpaceType { get; set; }
+    
+        /// <summary>What wall type should generally be created for this space type? This may get overridden later on for a specific wall.</summary>
+        [JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string DefaultWallType { get; set; }
     
     
     }

--- a/WorkplaceStrategy/DefineProgramRequirements/dependencies/DefineProgramRequirementsInputs.g.cs
+++ b/WorkplaceStrategy/DefineProgramRequirements/dependencies/DefineProgramRequirementsInputs.g.cs
@@ -218,12 +218,12 @@ namespace DefineProgramRequirements
     
     {
         [Newtonsoft.Json.JsonConstructor]
-        public ProgramRequirements(string @programGroup, string @programName, Color? @color, int @spaceCount, double @areaPerSpace, ProfileConstraint @dimensions, double? @width, double? @depth, string @hyparSpaceType, ProgramRequirementsCountType @countType, InputFolder @layoutType, bool? @enclosed)
+        public ProgramRequirements(string @programGroup, string @programName, Color? @color, int @spaceCount, double @areaPerSpace, ProfileConstraint @dimensions, double? @width, double? @depth, string @hyparSpaceType, ProgramRequirementsCountType @countType, InputFolder @layoutType, bool? @enclosed, ProgramRequirementsDefaultWallType? @defaultWallType)
         {
             var validator = Validator.Instance.GetFirstValidatorForType<ProgramRequirements>();
             if(validator != null)
             {
-                validator.PreConstruct(new object[]{ @programGroup, @programName, @color, @spaceCount, @areaPerSpace, @dimensions, @width, @depth, @hyparSpaceType, @countType, @layoutType, @enclosed});
+                validator.PreConstruct(new object[]{ @programGroup, @programName, @color, @spaceCount, @areaPerSpace, @dimensions, @width, @depth, @hyparSpaceType, @countType, @layoutType, @enclosed, @defaultWallType});
             }
         
             this.ProgramGroup = @programGroup;
@@ -238,6 +238,7 @@ namespace DefineProgramRequirements
             this.CountType = @countType;
             this.LayoutType = @layoutType;
             this.Enclosed = @enclosed;
+            this.DefaultWallType = @defaultWallType;
         
             if(validator != null)
             {
@@ -297,7 +298,12 @@ namespace DefineProgramRequirements
     
         /// <summary>Should this space be enclosed by walls?</summary>
         [Newtonsoft.Json.JsonProperty("Enclosed", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
-        public bool? Enclosed { get; set; } = true;
+        public bool? Enclosed { get; set; }
+    
+        /// <summary>What should the default wall type be for this space?</summary>
+        [Newtonsoft.Json.JsonProperty("Default Wall Type", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public ProgramRequirementsDefaultWallType? DefaultWallType { get; set; } = ProgramRequirementsDefaultWallType.None;
     
         private System.Collections.Generic.IDictionary<string, object> _additionalProperties = new System.Collections.Generic.Dictionary<string, object>();
     
@@ -317,6 +323,20 @@ namespace DefineProgramRequirements
     
         [System.Runtime.Serialization.EnumMember(Value = @"Area Total")]
         Area_Total = 1,
+    
+    }
+    
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "10.1.21.0 (Newtonsoft.Json v13.0.0.0)")]
+    public enum ProgramRequirementsDefaultWallType
+    {
+        [System.Runtime.Serialization.EnumMember(Value = @"None")]
+        None = 0,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"Solid")]
+        Solid = 1,
+    
+        [System.Runtime.Serialization.EnumMember(Value = @"Glass")]
+        Glass = 2,
     
     }
     

--- a/WorkplaceStrategy/DefineProgramRequirements/dependencies/ProgramRequirement.cs
+++ b/WorkplaceStrategy/DefineProgramRequirements/dependencies/ProgramRequirement.cs
@@ -15,5 +15,9 @@ namespace Elements
 
         public bool Enclosed { get; set; }
         public ProfileConstraint Dimensions { get; internal set; }
+
+        [JsonProperty("Default Wall Type")]
+        [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+        public ProgramRequirementsDefaultWallType? DefaultWallType { get; internal set; }
     }
 }

--- a/WorkplaceStrategy/DefineProgramRequirements/dependencies/ProgramRequirements.cs
+++ b/WorkplaceStrategy/DefineProgramRequirements/dependencies/ProgramRequirements.cs
@@ -23,7 +23,8 @@ public partial class ProgramRequirements
             CountType = (Elements.ProgramRequirementCountType)this.CountType,
             Catalog = catalogWrapper?.Id,
             Enclosed = this.Enclosed ?? false,
-            SpaceConfig = spaceConfigElem?.Id
+            SpaceConfig = spaceConfigElem?.Id,
+            DefaultWallType = this.DefaultWallType
         };
     }
 

--- a/WorkplaceStrategy/DefineProgramRequirements/hypar.json
+++ b/WorkplaceStrategy/DefineProgramRequirements/hypar.json
@@ -142,13 +142,27 @@
               ]
             },
             "Enclosed": {
+              "$hyparDeprecated": true,
               "description": "Should this space be enclosed by walls?",
               "type": [
                 "boolean",
                 "null"
               ],
               "$hyparStyle": "checkbox",
-              "default": true
+              "default": null
+            },
+            "Default Wall Type": {
+              "description": "What should the default wall type be for this space?",
+              "type": [
+                "string",
+                "null"
+              ],
+              "enum": [
+                "None",
+                "Solid",
+                "Glass"
+              ],
+              "default": "None"
             }
           }
         },

--- a/WorkplaceStrategy/DefineProgramRequirements/src/DefineProgramRequirements.cs
+++ b/WorkplaceStrategy/DefineProgramRequirements/src/DefineProgramRequirements.cs
@@ -182,7 +182,8 @@ namespace DefineProgramRequirements
                     "Circulation",
                     ProgramRequirementsCountType.Area_Total,
                     null,
-                    false
+                    false,
+                    ProgramRequirementsDefaultWallType.None
                 ));
             }
             if (!existingNames.Contains("Core"))
@@ -199,7 +200,8 @@ namespace DefineProgramRequirements
                     "Core",
                     ProgramRequirementsCountType.Area_Total,
                     null,
-                    true
+                    true,
+                    ProgramRequirementsDefaultWallType.None
                 ));
             }
         }


### PR DESCRIPTION
- Deprecate all `Create Walls` inputs to layout functions
- Update `LayoutFunctionCommon` to defer to the space's `Default Wall Type` rather than its built-in type preferences.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/67)
<!-- Reviewable:end -->
