### PR TITLE
Add rotation to the ContentConfiguration

### DIFF
--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -33,6 +33,12 @@ namespace LayoutFunctionCommon
                     layoutInstantiated.ConfigName = key;
                     break;
                 }
+                else if (config.AllowRotatation && config.CellBoundary.Depth < width + 0.01 && config.CellBoundary.Width < length + 0.01)
+                {
+                    layoutInstantiated.Config = GetRotatedConfig(config, -90);
+                    layoutInstantiated.ConfigName = key;
+                    break;
+                }
             }
             if (layoutInstantiated.Config == null)
             {
@@ -873,6 +879,34 @@ namespace LayoutFunctionCommon
             {
                 elementInstance.AdditionalProperties["Space"] = parentSpaceId;
             }
+        }
+
+        private static ContentConfiguration GetRotatedConfig(ContentConfiguration config, double degrees)
+        {
+            var transform = new Transform().Rotated(Vector3.ZAxis, degrees);
+            var box = new BBox3(new List<Vector3> { transform.OfPoint(config.CellBoundary.Min), transform.OfPoint(config.CellBoundary.Max) });
+
+            // Create new config
+            var newConfig = new ContentConfiguration()
+            {
+                CellBoundary = new ContentConfiguration.BoundaryDefinition() { Min = box.Min, Max = box.Max, },
+                ContentItems = new List<ContentConfiguration.ContentItem>()
+            };
+
+            foreach (var item in config.ContentItems)
+            {
+                var newItem = new ContentConfiguration.ContentItem()
+                {
+                    Url = item.Url,
+                    Name = item.Name,
+                    Transform = item.Transform.Concatenated(transform),
+                    Anchor = transform.OfPoint(item.Anchor)
+                };
+
+                newConfig.ContentItems.Add(newItem);
+            }
+
+            return newConfig;
         }
     }
 }


### PR DESCRIPTION
BACKGROUND:
- Configurations could not be rotated, so they were not selected unless they clearly fell within the width and length dimensions of the room

DESCRIPTION:
- This PR adds the ability to rotate the configuration by 90 degrees, if the AllowRotatation field of the configuration is set to "True" (depends on the PR: https://github.com/hypar-io/Elements/pull/1060). This way, the 90 degree rotated version of the configuration will be checked when trying to select it.

TESTING:
- To fill the room with furniture, use the "Space Type" function. When filling the rooms, the version of the configuration rotated by 90 degrees should be taken into account

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/73)
<!-- Reviewable:end -->
