### PR TITLE
Set parent space on generated furniture

### DIFF
--- a/LayoutFunctions/LayoutFunctionCommon/LayoutGeneration.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutGeneration.cs
@@ -82,7 +82,8 @@ namespace LayoutFunctionCommon
                         var (configInfo, wallCandidates) = SelectTheBestOfPossibleConfigs(possibleConfigs);
 
                         var layout = InstantiateLayoutByFit(configInfo, room.Transform);
-                        SetLevelVolume(layout.Instance, levelVolume?.Id);
+                        LayoutStrategies.SetLevelVolume(layout.Instance, levelVolume?.Id);
+                        LayoutStrategies.SetParentSpace(layout.Instance, room.Id);
                         wallCandidateLines.AddRange(wallCandidates);
                         outputModel.AddElement(layout.Instance);
                         seatsCount = CountSeats(layout);
@@ -288,20 +289,6 @@ namespace LayoutFunctionCommon
         protected virtual SeatsCount CountSeats(LayoutInstantiated layoutInstantiated)
         {
             return new SeatsCount(0, 0, 0, 0);
-        }
-
-        private static void SetLevelVolume(ComponentInstance componentInstance, Guid? levelVolumeId)
-        {
-            if (componentInstance != null)
-            {
-                foreach (var instance in componentInstance.Instances)
-                {
-                    if (instance != null)
-                    {
-                        instance.AdditionalProperties["Level"] = levelVolumeId;
-                    }
-                }
-            }
         }
     }
 }

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -352,6 +352,7 @@ namespace LayoutFunctionCommon
                     {
                         success = true;
                         SetLevelVolume(layout.Instance, levelVolume?.Id);
+                        SetParentSpace(layout.Instance, room.Id);
 
                         wallCandidateLines.AddRange(WallCandidates);
 
@@ -845,6 +846,20 @@ namespace LayoutFunctionCommon
                     if (instance != null)
                     {
                         instance.AdditionalProperties["Level"] = levelVolumeId;
+                    }
+                }
+            }
+        }
+
+        public static void SetParentSpace(ComponentInstance componentInstance, Guid? parentSpaceId)
+        {
+            if (componentInstance != null)
+            {
+                foreach (var instance in componentInstance.Instances)
+                {
+                    if (instance != null)
+                    {
+                        instance.AdditionalProperties["Space"] = parentSpaceId;
                     }
                 }
             }


### PR DESCRIPTION
For Pringle, we need to set the "Space" property on generated furniture. This will also help with future 'per-parent' overrides. 
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/75)
<!-- Reviewable:end -->
