### PR TITLE
Height fix and circulation space for doors

### DIFF
--- a/LayoutFunctions/LayoutFunctionCommon/ISpaceBoundary.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/ISpaceBoundary.cs
@@ -9,9 +9,9 @@ namespace Elements
     public interface ISpaceBoundary
     {
         string Name { get; set; }
+        double Height { get; set; }
         Profile Boundary { get; set; }
         Transform Transform { get; set; }
-
         Vector3? ParentCentroid { get; set; }
 
         Guid Id { get; set; }

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -205,24 +205,24 @@ namespace LayoutFunctionCommon
                     (lvl.AdditionalProperties.TryGetValue("LevelVolumeId", out var levelVolumeId) &&
                         levelVolumeId as string == l.Id.ToString())) ??
                         levelVolumes.FirstOrDefault(l => l.Name == lvl.Name);
-                var wallCandidateLines = new List<RoomEdge>();
                 foreach (var room in roomBoundaries)
                 {
+                    var wallCandidateLines = new List<RoomEdge>();
                     var layoutSucceeded = ProcessRoom(room, outputModel, countSeats, configs, corridorSegments, levelVolume, wallCandidateLines);
                     if (layoutSucceeded) { processedSpaces.Add(room.Id); }
-                }
 
-                double height = levelVolume?.Height ?? 3;
-                Transform xform = levelVolume?.Transform ?? new Transform();
+                    double height = room.Height == 0 ? 3 : room.Height;
+                    Transform xform = levelVolume?.Transform ?? new Transform();
 
-                if (createWalls && wallCandidateLines.Count > 0)
-                {
-                    outputModel.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
+                    if (createWalls && wallCandidateLines.Count > 0)
                     {
-                        WallCandidateLines = wallCandidateLines,
-                        Height = height,
-                        LevelTransform = xform,
-                    });
+                        outputModel.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
+                        {
+                            WallCandidateLines = wallCandidateLines,
+                            Height = height,
+                            LevelTransform = xform,
+                        });
+                    }
                 }
             }
             foreach (var room in allSpaceBoundaries)
@@ -273,21 +273,22 @@ namespace LayoutFunctionCommon
                     (lvl.AdditionalProperties.TryGetValue("LevelVolumeId", out var levelVolumeId) &&
                         levelVolumeId as string == l.Id.ToString())) ??
                         levelVolumes.FirstOrDefault(l => l.Name == lvl.Name);
-                var wallCandidateLines = new List<RoomEdge>();
+
                 foreach (var room in roomBoundaries)
                 {
+                    var wallCandidateLines = new List<RoomEdge>();
                     GenerateWallsForSpace(room, levelVolume, corridorSegments, wallCandidateLines);
+
+                    double height = room.Height == 0 ? 3 : room.Height;
+                    Transform xform = levelVolume?.Transform ?? new Transform();
+
+                    outputModel.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
+                    {
+                        WallCandidateLines = wallCandidateLines,
+                        Height = height,
+                        LevelTransform = xform,
+                    });
                 }
-
-                double height = levelVolume?.Height ?? 3;
-                Transform xform = levelVolume?.Transform ?? new Transform();
-
-                outputModel.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
-                {
-                    WallCandidateLines = wallCandidateLines,
-                    Height = height,
-                    LevelTransform = xform,
-                });
             }
             foreach (var room in allSpaceBoundaries)
             {

--- a/LayoutFunctions/PrivateOfficeLayout/dependencies/CirculationSegment.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/dependencies/CirculationSegment.cs
@@ -1,0 +1,6 @@
+namespace Elements
+{
+    public partial class CirculationSegment : ICirculationSegment
+    {
+    }
+}

--- a/LayoutFunctions/PrivateOfficeLayout/dependencies/LevelVolume.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/dependencies/LevelVolume.cs
@@ -1,0 +1,6 @@
+namespace Elements
+{
+    public partial class LevelVolume : ILevelVolume
+    {
+    }
+}


### PR DESCRIPTION
BACKGROUND:
- Circulation spaces were not being included in the `Doors` function.
- We somehow reverted (or forgot?) to using the LevelVolume height instead of the Room height for wall generation.

DESCRIPTION:
- Adds Spaces with `ProgramType` of `Circulation` to the edges to be check for door placement
- Updates the height of walls to be created using the room (`SpaceBoundary`) height instead of the `LevelVolume` height

TESTING:
- See `Doors` respond to the Circulation Space Type
- Review walls beteween multi-story levels

https://hypar.io/workflows/23d33fb9-e90f-427b-b94a-6a12d04a4109?view=Floors%3BLevel%20Group%201%3A%20Level%201
  
FUTURE WORK:
- Some space types still may need to be updated to reflect these changes... Hoping to move towards a unified `Space Type` function and do away with older Space Layout functions.

REQUIRED:
- [ ] All changes are up to date in `CHANGELOG.md`.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/77)
<!-- Reviewable:end -->
