### PR TITLE
add space associations for all child elements

### DIFF
--- a/LayoutFunctions/ClassroomLayout/src/ClassroomLayout.cs
+++ b/LayoutFunctions/ClassroomLayout/src/ClassroomLayout.cs
@@ -92,6 +92,7 @@ namespace ClassroomLayout
                         {
                             var componentInstance = InstantiateLayout(configs, width, depth, rect, room.Transform);
                             LayoutStrategies.SetLevelVolume(componentInstance, levelVolume?.Id);
+                            LayoutStrategies.SetParentSpace(componentInstance, room.Id);
                             output.Model.AddElement(componentInstance);
                         }
                         else if (trimmedGeo.Count() > 0)
@@ -102,6 +103,7 @@ namespace ClassroomLayout
 
                             var componentInstance = InstantiateLayout(configs, width, depth, cinchedPoly, room.Transform);
                             LayoutStrategies.SetLevelVolume(componentInstance, levelVolume?.Id);
+                            LayoutStrategies.SetParentSpace(componentInstance, room.Id);
                             output.Model.AddElement(componentInstance);
                         }
                         try
@@ -135,6 +137,7 @@ namespace ClassroomLayout
                                                 "Desk");
 
                                             LayoutStrategies.SetLevelVolume(instance, levelVolume?.Id);
+                                            LayoutStrategies.SetParentSpace(instance, room.Id);
                                             output.Model.AddElement(instance);
                                         }
                                     }

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutFunctionCommon.csproj
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutFunctionCommon.csproj
@@ -17,13 +17,11 @@
   <ItemGroup>
   </ItemGroup>
   <ItemGroup>
-  <PackageReference Include="Hypar.Elements" Version="2.2.0-alpha.17" />
-    <PackageReference Include="Hypar.Functions" Version="1.11.0-alpha.10" />
+    <PackageReference Include="Hypar.Elements" Version="2.2.0-alpha.17" />
     <PackageReference Include="Hypar.Elements.Components" Version="2.2.0-alpha.17" />
     <!-- <ProjectReference Include="..\..\..\Elements\Elements\src\Elements.csproj" />
-    <ProjectReference Include="..\..\..\Hypar\Hypar.Functions\src\Hypar.Functions.csproj" />
     <ProjectReference Include="..\..\..\Elements\Elements.Components\src\Elements.Components.csproj" /> -->
-
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
     <PackageReference Include="Elements.LargestInteriorRectangle" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -865,5 +865,13 @@ namespace LayoutFunctionCommon
                 }
             }
         }
+
+        public static void SetParentSpace(ElementInstance elementInstance, Guid parentSpaceId)
+        {
+            if (elementInstance != null)
+            {
+                elementInstance.AdditionalProperties["Space"] = parentSpaceId;
+            }
+        }
     }
 }

--- a/LayoutFunctions/OpenOfficeLayout/Model.dib
+++ b/LayoutFunctions/OpenOfficeLayout/Model.dib
@@ -1,0 +1,12 @@
+#!meta
+
+{"kernelInfo":{"defaultKernelName":"csharp","items":[{"aliases":[],"name":"csharp"}]}}
+
+#!csharp
+
+#r "nuget: Hypar.Elements, *-*"
+
+#!csharp
+
+var modelPath = "/Users/andrewheumann/Downloads/model 45.json";
+Model.FromJson(File)

--- a/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayout.cs
+++ b/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayout.cs
@@ -182,6 +182,7 @@ namespace OpenOfficeLayout
                             foreach (var desk in desks)
                             {
                                 LayoutStrategies.SetLevelVolume(desk as ElementInstance, levelVolume?.Id);
+                                LayoutStrategies.SetParentSpace(desk as ElementInstance, ob.Id);
                             }
                             output.Model.AddElements(desks);
 

--- a/LayoutFunctions/OpenOfficeLayout/test/Generated/OpenOfficeLayoutTest/model_dependencies/Space Planning Zones/json/63c2e0df-0d5a-4fd5-a18e-cd7aec794356_998eb115-7d70-49df-9fbe-fbc96a91ae3d_elements.zip
+++ b/LayoutFunctions/OpenOfficeLayout/test/Generated/OpenOfficeLayoutTest/model_dependencies/Space Planning Zones/json/63c2e0df-0d5a-4fd5-a18e-cd7aec794356_998eb115-7d70-49df-9fbe-fbc96a91ae3d_elements.zip
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>EKN5BGA37XK4SY88</RequestId><HostId>QVRfH3TrGZQKXsMveW3bcXf2M6ghPoasNYLw2g7c0lGb3OSFD7Lf4OOK6sPbkgZLd10nxN6Fjhc=</HostId></Error>

--- a/LayoutFunctions/OpenOfficeLayout/test/Generated/OpenOfficeLayoutTest/model_dependencies/Space Planning Zones/json/ddbadd4c-8ebc-4911-af73-5f52ba7a5382_998eb115-7d70-49df-9fbe-fbc96a91ae3d_elements.zip
+++ b/LayoutFunctions/OpenOfficeLayout/test/Generated/OpenOfficeLayoutTest/model_dependencies/Space Planning Zones/json/ddbadd4c-8ebc-4911-af73-5f52ba7a5382_998eb115-7d70-49df-9fbe-fbc96a91ae3d_elements.zip
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>CMH857YEYZ5WRC90</RequestId><HostId>hOtw+YejhNRIAP2YyzyqSnUjP3wPHraUapiGGnH8Mwq0k6kSQLGiP2KlSyrql96/d6PcnrsdF0o=</HostId></Error>

--- a/LayoutFunctions/PhoneBoothLayout/src/PhoneBoothLayout.cs
+++ b/LayoutFunctions/PhoneBoothLayout/src/PhoneBoothLayout.cs
@@ -98,6 +98,7 @@ namespace PhoneBoothLayout
                             if (layout != null)
                             {
                                 LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
+                                LayoutStrategies.SetParentSpace(layout, room.Id);
                                 output.Model.AddElement(layout);
                                 seatsCount++;
                             }
@@ -112,6 +113,7 @@ namespace PhoneBoothLayout
                             if (layout != null)
                             {
                                 LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
+                                LayoutStrategies.SetParentSpace(layout, room.Id);
                                 output.Model.AddElement(layout);
                                 seatsCount++;
                             }

--- a/LayoutFunctions/PrivateOfficeLayout/src/PrivateOfficeLayout.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/src/PrivateOfficeLayout.cs
@@ -120,6 +120,7 @@ namespace PrivateOfficeLayout
                             {
                                 var layout = InstantiateLayout(configs, width, depth, rect, levelVolume?.Transform ?? new Transform(), out var seats);
                                 LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
+                                LayoutStrategies.SetParentSpace(layout, room.Id);
                                 output.Model.AddElement(layout);
                                 privateOfficeCount++;
                                 seatsCount += seats;
@@ -134,6 +135,7 @@ namespace PrivateOfficeLayout
                                 {
                                     var layout = InstantiateLayout(configs, width, depth, cinchedPoly, levelVolume?.Transform ?? new Transform(), out var seats);
                                     LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
+                                    LayoutStrategies.SetParentSpace(layout, room.Id);
                                     output.Model.AddElement(layout);
                                     privateOfficeCount++;
                                     seatsCount += seats;

--- a/LayoutFunctions/ReceptionLayout/src/ReceptionLayout.cs
+++ b/LayoutFunctions/ReceptionLayout/src/ReceptionLayout.cs
@@ -93,6 +93,7 @@ namespace ReceptionLayout
                         {
                             var layout = InstantiateLayout(configs, width, depth, rect, room.Transform, out var seats);
                             LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
+                            LayoutStrategies.SetParentSpace(layout, room.Id);
                             output.Model.AddElement(layout);
                             seatsCount += seats;
                         }
@@ -104,6 +105,7 @@ namespace ReceptionLayout
                             // output.Model.AddElement(new ModelCurve(cinchedPoly, BuiltInMaterials.ZAxis, levelVolume.Transform));
                             var layout = InstantiateLayout(configs, width, depth, cinchedPoly, room.Transform, out var seats);
                             LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
+                            LayoutStrategies.SetParentSpace(layout, room.Id);
                             output.Model.AddElement(layout);
                             Console.WriteLine("🤷‍♂️ funny shape!!!");
                             seatsCount += seats;


### PR DESCRIPTION
in #75, we added a default behavior to `LayoutFunctionCommon` for associating a `Space` property with elements generated for a space. In this PR, we make sure all non-standard spaces also specify this property. This prepares us for future "per-parent override" type relationships for furniture, and also makes pringle smoother, letting all generated elements travel along with the space without having to do a "containment" check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/78)
<!-- Reviewable:end -->
