### PR TITLE
thickness preservation

### DIFF
--- a/LayoutFunctions/InteriorPartitions/server/InteriorPartitions.Server.csproj
+++ b/LayoutFunctions/InteriorPartitions/server/InteriorPartitions.Server.csproj
@@ -2,7 +2,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\InteriorPartitions.csproj" />
-    <ProjectReference Include="..\..\..\..\Hypar\Hypar.Server\Hypar.Server.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Hypar.Server" Version="1.11.0-alpha.10" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/LayoutFunctions/InteriorPartitions/src/InteriorPartitions.cs
+++ b/LayoutFunctions/InteriorPartitions/src/InteriorPartitions.cs
@@ -93,7 +93,11 @@ namespace InteriorPartitions
             {
                 if (wallCandidateCheck.Thickness == null || wallCandidate.Thickness == null) continue;
 
+                // This ensures that we are always extending the wall with the larger thickness
+                if ((wallCandidateCheck.Thickness.Value.outerWidth + wallCandidateCheck.Thickness.Value.innerWidth) < (wallCandidate.Thickness.Value.outerWidth + wallCandidate.Thickness.Value.innerWidth)) continue;
+
                 UpdateWallCandidateLines(wallCandidate, wallCandidateCheck, wallCandidates, wallCandidatesDictionary);
+
             }
         }
 
@@ -411,10 +415,23 @@ namespace InteriorPartitions
                     })
                     .ToList();
 
+                var levelGroupWallCandidateLines = levelGroup.SelectMany(x => x.WallCandidateLines).ToList();
+
+                foreach (var splittedCandidate in splittedWallCandidates)
+                {
+                    var closestInteriorPartition = levelGroupWallCandidateLines.OrderBy(x => splittedCandidate.Line.Mid().DistanceTo(x.Line)).First();
+
+                    splittedCandidate.Thickness = closestInteriorPartition.Thickness;
+                }
+
                 wallCandidates.AddRange(splittedWallCandidates);
             }
 
             AttachOverrides(input.Overrides.InteriorPartitionTypes, wallCandidates);
+
+            foreach (var wallCandidate in wallCandidates)
+            {
+            }
 
             return wallCandidates;
         }

--- a/LayoutFunctions/InteriorPartitions/src/InteriorPartitions.cs
+++ b/LayoutFunctions/InteriorPartitions/src/InteriorPartitions.cs
@@ -94,7 +94,7 @@ namespace InteriorPartitions
                 if (wallCandidateCheck.Thickness == null || wallCandidate.Thickness == null) continue;
 
                 // This ensures that we are always extending the wall with the larger thickness
-                if ((wallCandidateCheck.Thickness.Value.outerWidth + wallCandidateCheck.Thickness.Value.innerWidth) < (wallCandidate.Thickness.Value.outerWidth + wallCandidate.Thickness.Value.innerWidth)) continue;
+                if (GetTotalWidth(wallCandidateCheck.Thickness.Value) < GetTotalWidth(wallCandidate.Thickness.Value)) continue;
 
                 UpdateWallCandidateLines(wallCandidate, wallCandidateCheck, wallCandidates, wallCandidatesDictionary);
 
@@ -428,10 +428,6 @@ namespace InteriorPartitions
             }
 
             AttachOverrides(input.Overrides.InteriorPartitionTypes, wallCandidates);
-
-            foreach (var wallCandidate in wallCandidates)
-            {
-            }
 
             return wallCandidates;
         }


### PR DESCRIPTION
- Update the Interior Partitions function to preserve thickness when it is modified
- This was previously being overriden when removing overlapping walls and splitting. 
- I also updated the wall trim / extension to extend the thicker wall first in corners, which I think looks the least weird

Shared workflow here if you want to see it
https://hypar.io/workflows/5fbc7b87-0102-48ee-86f1-140eff24395e

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/80)
<!-- Reviewable:end -->
