### PR TITLE
Update LayoutStrategies.cs

### DIFF
--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -33,7 +33,7 @@ namespace LayoutFunctionCommon
                     layoutInstantiated.ConfigName = key;
                     break;
                 }
-                else if (config.AllowRotatation && config.CellBoundary.Depth < width + 0.01 && config.CellBoundary.Width < length + 0.01)
+                else if (config.AllowRotation && config.CellBoundary.Depth < width + 0.01 && config.CellBoundary.Width < length + 0.01)
                 {
                     layoutInstantiated.Config = GetRotatedConfig(config, -90);
                     layoutInstantiated.ConfigName = key;


### PR DESCRIPTION
fix a spelling mistake that has since been fixed on elements

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/82)
<!-- Reviewable:end -->
