### PR TITLE
updates to stream_model before republishing layout functions

### DIFF
--- a/LayoutFunctions/ClassroomLayout/hypar.json
+++ b/LayoutFunctions/ClassroomLayout/hypar.json
@@ -77,5 +77,6 @@
   ],
   "repository_url": "https://github.com/hypar-io/function",
   "source_file_key": null,
-  "preview_image": null
+  "preview_image": null,
+  "stream_model": true
 }

--- a/LayoutFunctions/ClassroomLayout/src/Function.g.cs
+++ b/LayoutFunctions/ClassroomLayout/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace ClassroomLayout
             {
                 this.store = new UrlModelStore<ClassroomLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<ClassroomLayoutInputs,ClassroomLayoutOutputs> (store, ClassroomLayout.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/DataHall/hypar.json
+++ b/LayoutFunctions/DataHall/hypar.json
@@ -111,5 +111,6 @@
   "repository_url": "https://github.com/hypar-io/function",
   "source_file_key": null,
   "preview_image": null,
-  "thumbnail_id": null
+  "thumbnail_id": null,
+  "stream_model": true
 }

--- a/LayoutFunctions/DataHall/src/Function.g.cs
+++ b/LayoutFunctions/DataHall/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace DataHallLayout
             {
                 this.store = new UrlModelStore<DataHallLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<DataHallLayoutInputs,DataHallLayoutOutputs> (store, DataHallLayout.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/InteriorPartitions/src/Function.g.cs
+++ b/LayoutFunctions/InteriorPartitions/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace InteriorPartitions
             {
                 this.store = new UrlModelStore<InteriorPartitionsInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<InteriorPartitionsInputs,InteriorPartitionsOutputs> (store, InteriorPartitions.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/LoungeLayout/hypar.json
+++ b/LayoutFunctions/LoungeLayout/hypar.json
@@ -58,5 +58,6 @@
   ],
   "repository_url": "https://github.com/hypar-io/function",
   "source_file_key": null,
-  "preview_image": null
+  "preview_image": null,
+  "stream_model": true
 }

--- a/LayoutFunctions/LoungeLayout/src/Function.g.cs
+++ b/LayoutFunctions/LoungeLayout/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace LoungeLayout
             {
                 this.store = new UrlModelStore<LoungeLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<LoungeLayoutInputs,LoungeLayoutOutputs> (store, LoungeLayout.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/MeetingRoomLayout/hypar.json
+++ b/LayoutFunctions/MeetingRoomLayout/hypar.json
@@ -75,5 +75,6 @@
     "https://schemas.hypar.io/CirculationSegment.json",
     "https://schemas.hypar.io/LevelVolume.json",
     "https://schemas.hypar.io/RoomTally.json"
-  ]
+  ],
+  "stream_model": true
 }

--- a/LayoutFunctions/MeetingRoomLayout/src/Function.g.cs
+++ b/LayoutFunctions/MeetingRoomLayout/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace MeetingRoomLayout
             {
                 this.store = new UrlModelStore<MeetingRoomLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<MeetingRoomLayoutInputs,MeetingRoomLayoutOutputs> (store, MeetingRoomLayout.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/OpenCollabLayout/hypar.json
+++ b/LayoutFunctions/OpenCollabLayout/hypar.json
@@ -73,5 +73,6 @@
   "repository_url": "https://github.com/hypar-io/function",
   "source_file_key": null,
   "preview_image": null,
-  "thumbnail_id": null
+  "thumbnail_id": null,
+  "stream_model": true
 }

--- a/LayoutFunctions/OpenCollabLayout/src/Function.g.cs
+++ b/LayoutFunctions/OpenCollabLayout/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace OpenCollaborationLayout
             {
                 this.store = new UrlModelStore<OpenCollaborationLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<OpenCollaborationLayoutInputs,OpenCollaborationLayoutOutputs> (store, OpenCollaborationLayout.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/OpenOfficeLayout/hypar.json
+++ b/LayoutFunctions/OpenOfficeLayout/hypar.json
@@ -293,5 +293,6 @@
   "default_camera": {
     "named_position": "top",
     "projection": "orthographic"
-  }
+  },
+  "stream_model": true
 }

--- a/LayoutFunctions/OpenOfficeLayout/src/Function.g.cs
+++ b/LayoutFunctions/OpenOfficeLayout/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace OpenOfficeLayout
             {
                 this.store = new UrlModelStore<OpenOfficeLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<OpenOfficeLayoutInputs,OpenOfficeLayoutOutputs> (store, OpenOfficeLayout.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/PantryLayout/hypar.json
+++ b/LayoutFunctions/PantryLayout/hypar.json
@@ -66,5 +66,6 @@
   ],
   "repository_url": "https://github.com/hypar-io/function",
   "source_file_key": null,
-  "preview_image": null
+  "preview_image": null,
+  "stream_model": true
 }

--- a/LayoutFunctions/PantryLayout/src/Function.g.cs
+++ b/LayoutFunctions/PantryLayout/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace PantryLayout
             {
                 this.store = new UrlModelStore<PantryLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<PantryLayoutInputs,PantryLayoutOutputs> (store, PantryLayout.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/PhoneBoothLayout/hypar.json
+++ b/LayoutFunctions/PhoneBoothLayout/hypar.json
@@ -84,5 +84,6 @@
   ],
   "repository_url": "https://github.com/hypar-io/function",
   "source_file_key": null,
-  "preview_image": null
+  "preview_image": null,
+  "stream_model": true
 }

--- a/LayoutFunctions/PhoneBoothLayout/src/Function.g.cs
+++ b/LayoutFunctions/PhoneBoothLayout/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace PhoneBoothLayout
             {
                 this.store = new UrlModelStore<PhoneBoothLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<PhoneBoothLayoutInputs,PhoneBoothLayoutOutputs> (store, PhoneBoothLayout.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/PrivateOfficeLayout/dependencies/PrivateOfficeLayout.Dependencies.csproj
+++ b/LayoutFunctions/PrivateOfficeLayout/dependencies/PrivateOfficeLayout.Dependencies.csproj
@@ -4,8 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\LayoutFunctionCommon\LayoutFunctionCommon.csproj" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="Hypar.Elements" Version="2.2.0-alpha.21" />
     <PackageReference Include="Hypar.Functions" Version="1.11.0-alpha.13" />
   </ItemGroup>

--- a/LayoutFunctions/PrivateOfficeLayout/server/PrivateOfficeLayout.Server.csproj
+++ b/LayoutFunctions/PrivateOfficeLayout/server/PrivateOfficeLayout.Server.csproj
@@ -2,10 +2,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\src\PrivateOfficeLayout.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Hypar.Server" Version="1.11.0-alpha.13" />
+    <ProjectReference Include="..\..\..\..\Hypar\Hypar.Server\Hypar.Server.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/LayoutFunctions/PrivateOfficeLayout/src/Function.g.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace PrivateOfficeLayout
             {
                 this.store = new UrlModelStore<PrivateOfficeLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<PrivateOfficeLayoutInputs,PrivateOfficeLayoutOutputs> (store, PrivateOfficeLayout.Execute);
             var output = await l.InvokeAsync(args);

--- a/LayoutFunctions/ReceptionLayout/hypar.json
+++ b/LayoutFunctions/ReceptionLayout/hypar.json
@@ -63,5 +63,6 @@
   ],
   "repository_url": "https://github.com/hypar-io/function",
   "source_file_key": null,
-  "preview_image": null
+  "preview_image": null,
+  "stream_model": true
 }

--- a/LayoutFunctions/ReceptionLayout/src/Function.g.cs
+++ b/LayoutFunctions/ReceptionLayout/src/Function.g.cs
@@ -63,7 +63,7 @@ namespace ReceptionLayout
             {
                 this.store = new UrlModelStore<ReceptionLayoutInputs>();
             }
-            
+            args.StreamModel = true;
 
             var l = new InvocationWrapper<ReceptionLayoutInputs,ReceptionLayoutOutputs> (store, ReceptionLayout.Execute);
             var output = await l.InvokeAsync(args);


### PR DESCRIPTION
Re-publishing functions using the latest Elements and Function versions so that we don't get 404 errors anymore

Tested in this workflow:
https://hypar.io/workflows/95f5e074-2eb7-4c44-8076-b39a78f5ccb8?view=b09eebe9-9857-4fcf-92e4-e4173e928289

I also ran migration tests and saw no issues.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/84)
<!-- Reviewable:end -->
