### PR TITLE
set boundary too

### DIFF
--- a/LayoutFunctions/ClassroomLayout/src/ClassroomLayout.cs
+++ b/LayoutFunctions/ClassroomLayout/src/ClassroomLayout.cs
@@ -92,7 +92,7 @@ namespace ClassroomLayout
                         {
                             var componentInstance = InstantiateLayout(configs, width, depth, rect, room.Transform);
                             LayoutStrategies.SetLevelVolume(componentInstance, levelVolume?.Id);
-                            LayoutStrategies.SetParentSpace(componentInstance, room.Id);
+                            LayoutStrategies.SetParentSpace(componentInstance, room);
                             output.Model.AddElement(componentInstance);
                         }
                         else if (trimmedGeo.Count() > 0)
@@ -103,7 +103,7 @@ namespace ClassroomLayout
 
                             var componentInstance = InstantiateLayout(configs, width, depth, cinchedPoly, room.Transform);
                             LayoutStrategies.SetLevelVolume(componentInstance, levelVolume?.Id);
-                            LayoutStrategies.SetParentSpace(componentInstance, room.Id);
+                            LayoutStrategies.SetParentSpace(componentInstance, room);
                             output.Model.AddElement(componentInstance);
                         }
                         try
@@ -137,7 +137,7 @@ namespace ClassroomLayout
                                                 "Desk");
 
                                             LayoutStrategies.SetLevelVolume(instance, levelVolume?.Id);
-                                            LayoutStrategies.SetParentSpace(instance, room.Id);
+                                            LayoutStrategies.SetParentSpace(instance, room);
                                             output.Model.AddElement(instance);
                                         }
                                     }

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutGeneration.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutGeneration.cs
@@ -83,7 +83,7 @@ namespace LayoutFunctionCommon
 
                         var layout = InstantiateLayoutByFit(configInfo, room.Transform);
                         LayoutStrategies.SetLevelVolume(layout.Instance, levelVolume?.Id);
-                        LayoutStrategies.SetParentSpace(layout.Instance, room.Id);
+                        LayoutStrategies.SetParentSpace(layout.Instance, room);
                         wallCandidateLines.AddRange(wallCandidates);
                         outputModel.AddElement(layout.Instance);
                         seatsCount = CountSeats(layout);

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -360,7 +360,7 @@ namespace LayoutFunctionCommon
                     {
                         success = true;
                         SetLevelVolume(layout.Instance, levelVolume?.Id);
-                        SetParentSpace(layout.Instance, room.Id);
+                        SetParentSpace(layout.Instance, room);
 
                         wallCandidateLines.AddRange(WallCandidates);
 
@@ -859,7 +859,7 @@ namespace LayoutFunctionCommon
             }
         }
 
-        public static void SetParentSpace(ComponentInstance componentInstance, Guid? parentSpaceId)
+        public static void SetParentSpace(ComponentInstance componentInstance, ISpaceBoundary parentSpaceBoundary)
         {
             if (componentInstance != null)
             {
@@ -867,17 +867,19 @@ namespace LayoutFunctionCommon
                 {
                     if (instance != null)
                     {
-                        instance.AdditionalProperties["Space"] = parentSpaceId;
+                        instance.AdditionalProperties["Space"] = parentSpaceBoundary.Id;
+                        instance.AdditionalProperties["Space Boundary"] = parentSpaceBoundary.Boundary.Perimeter.TransformedPolygon(parentSpaceBoundary.Transform).Vertices;
                     }
                 }
             }
         }
 
-        public static void SetParentSpace(ElementInstance elementInstance, Guid parentSpaceId)
+        public static void SetParentSpace(ElementInstance elementInstance, ISpaceBoundary parentSpaceBoundary)
         {
             if (elementInstance != null)
             {
-                elementInstance.AdditionalProperties["Space"] = parentSpaceId;
+                elementInstance.AdditionalProperties["Space"] = parentSpaceBoundary.Id;
+                elementInstance.AdditionalProperties["Space Boundary"] = parentSpaceBoundary.Boundary.Perimeter.TransformedPolygon(parentSpaceBoundary.Transform).Vertices;
             }
         }
 

--- a/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayout.cs
+++ b/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayout.cs
@@ -182,7 +182,7 @@ namespace OpenOfficeLayout
                             foreach (var desk in desks)
                             {
                                 LayoutStrategies.SetLevelVolume(desk as ElementInstance, levelVolume?.Id);
-                                LayoutStrategies.SetParentSpace(desk as ElementInstance, ob.Id);
+                                LayoutStrategies.SetParentSpace(desk as ElementInstance, ob);
                             }
                             output.Model.AddElements(desks);
 

--- a/LayoutFunctions/PhoneBoothLayout/src/PhoneBoothLayout.cs
+++ b/LayoutFunctions/PhoneBoothLayout/src/PhoneBoothLayout.cs
@@ -98,7 +98,7 @@ namespace PhoneBoothLayout
                             if (layout != null)
                             {
                                 LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
-                                LayoutStrategies.SetParentSpace(layout, room.Id);
+                                LayoutStrategies.SetParentSpace(layout, room);
                                 output.Model.AddElement(layout);
                                 seatsCount++;
                             }
@@ -113,7 +113,7 @@ namespace PhoneBoothLayout
                             if (layout != null)
                             {
                                 LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
-                                LayoutStrategies.SetParentSpace(layout, room.Id);
+                                LayoutStrategies.SetParentSpace(layout, room);
                                 output.Model.AddElement(layout);
                                 seatsCount++;
                             }

--- a/LayoutFunctions/PrivateOfficeLayout/src/PrivateOfficeLayout.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/src/PrivateOfficeLayout.cs
@@ -120,7 +120,7 @@ namespace PrivateOfficeLayout
                             {
                                 var layout = InstantiateLayout(configs, width, depth, rect, levelVolume?.Transform ?? new Transform(), out var seats);
                                 LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
-                                LayoutStrategies.SetParentSpace(layout, room.Id);
+                                LayoutStrategies.SetParentSpace(layout, room);
                                 output.Model.AddElement(layout);
                                 privateOfficeCount++;
                                 seatsCount += seats;
@@ -135,7 +135,7 @@ namespace PrivateOfficeLayout
                                 {
                                     var layout = InstantiateLayout(configs, width, depth, cinchedPoly, levelVolume?.Transform ?? new Transform(), out var seats);
                                     LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
-                                    LayoutStrategies.SetParentSpace(layout, room.Id);
+                                    LayoutStrategies.SetParentSpace(layout, room);
                                     output.Model.AddElement(layout);
                                     privateOfficeCount++;
                                     seatsCount += seats;

--- a/LayoutFunctions/ReceptionLayout/src/ReceptionLayout.cs
+++ b/LayoutFunctions/ReceptionLayout/src/ReceptionLayout.cs
@@ -93,7 +93,7 @@ namespace ReceptionLayout
                         {
                             var layout = InstantiateLayout(configs, width, depth, rect, room.Transform, out var seats);
                             LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
-                            LayoutStrategies.SetParentSpace(layout, room.Id);
+                            LayoutStrategies.SetParentSpace(layout, room);
                             output.Model.AddElement(layout);
                             seatsCount += seats;
                         }
@@ -105,7 +105,7 @@ namespace ReceptionLayout
                             // output.Model.AddElement(new ModelCurve(cinchedPoly, BuiltInMaterials.ZAxis, levelVolume.Transform));
                             var layout = InstantiateLayout(configs, width, depth, cinchedPoly, room.Transform, out var seats);
                             LayoutStrategies.SetLevelVolume(layout, levelVolume?.Id);
-                            LayoutStrategies.SetParentSpace(layout, room.Id);
+                            LayoutStrategies.SetParentSpace(layout, room);
                             output.Model.AddElement(layout);
                             Console.WriteLine("🤷‍♂️ funny shape!!!");
                             seatsCount += seats;


### PR DESCRIPTION
A small tweak for pringle — stash the space boundary each room was generated from on each object. This lets us restore them to the correct position even if the space has moved since the furniture was generated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/85)
<!-- Reviewable:end -->
