### PR TITLE
Limit configs based on `ConfigId` property

### DIFF
--- a/LayoutFunctions/ClassroomLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/ClassroomLayout/dependencies/SpaceBoundary.cs
@@ -1,9 +1,13 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
 
 namespace Elements
 {
     public partial class SpaceBoundary : GeometricElement, ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
+        
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }

--- a/LayoutFunctions/CustomLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/CustomLayout/dependencies/SpaceBoundary.cs
@@ -1,9 +1,13 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
 
 namespace Elements
 {
     public partial class SpaceBoundary : GeometricElement, ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
+
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }

--- a/LayoutFunctions/LayoutFunctionCommon/ISpaceBoundary.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/ISpaceBoundary.cs
@@ -21,6 +21,9 @@ namespace Elements
 
         public string DefaultWallType { get; set; }
 
+        [JsonProperty("Config Id", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public string ConfigId { get; set; }
+
     }
 
 }

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutGeneration.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutGeneration.cs
@@ -61,6 +61,12 @@ namespace LayoutFunctionCommon
                     };
                     boundaryCurves.AddRange(spaceBoundary.Voids ?? new List<Polygon>());
 
+                    var configsForRoom = configs;
+                    if (room.ConfigId != null)
+                    {
+                        configsForRoom = LayoutStrategies.LimitConfigsToId(configs, room, wallCandidateOptions);
+                    }
+
                     var possibleConfigs = new List<(ConfigInfo configInfo, List<RoomEdge> wallCandidates)>();
                     foreach (var (OrientationGuideEdge, WallCandidates) in wallCandidateOptions)
                     {
@@ -68,7 +74,7 @@ namespace LayoutFunctionCommon
                         var grid = new Grid2d(boundaryCurves, orientationTransform);
                         foreach (var cell in grid.GetCells())
                         {
-                            var config = FindConfigByFit(configs, cell);
+                            var config = FindConfigByFit(configsForRoom, cell);
                             if (config != null)
                             {
                                 possibleConfigs.Add((config.Value, WallCandidates));
@@ -238,7 +244,7 @@ namespace LayoutFunctionCommon
             KeyValuePair<string, ContentConfiguration>? selectedConfigPair = null;
             foreach (var configPair in orderedConfigs)
             {
-                if (configPair.Value.CellBoundary.Width < width && configPair.Value.CellBoundary.Depth < length)
+                if (configPair.Value.CellBoundary.Width < (width + Vector3.EPSILON) && configPair.Value.CellBoundary.Depth < (length + Vector3.EPSILON))
                 {
                     selectedConfigPair = configPair;
                     break;

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -211,7 +211,13 @@ namespace LayoutFunctionCommon
                 foreach (var room in roomBoundaries)
                 {
                     var wallCandidateLines = new List<RoomEdge>();
-                    var layoutSucceeded = ProcessRoom(room, outputModel, countSeats, configs, corridorSegments, levelVolume, wallCandidateLines);
+
+                    var configsForRoom = configs;
+                    if (room.ConfigId != null)
+                    {
+                        configsForRoom = LimitConfigsToId(configs, room);
+                    }
+                    var layoutSucceeded = ProcessRoom(room, outputModel, countSeats, configsForRoom, corridorSegments, levelVolume, wallCandidateLines);
                     if (layoutSucceeded) { processedSpaces.Add(room.Id); }
 
                     double height = room.Height == 0 ? 3 : room.Height;
@@ -238,6 +244,38 @@ namespace LayoutFunctionCommon
             }
             OverrideUtilities.InstancePositionOverrides(overrides, outputModel);
             return processedSpaces;
+        }
+
+        /// <summary>
+        /// Pringle-specific behavior to pick a specific config and orientation. This code only executes if the room has a `ConfigId` property, which is only set on pringle.
+        /// </summary>
+        public static SpaceConfiguration LimitConfigsToId<TSpaceBoundary>(SpaceConfiguration configs, TSpaceBoundary room, List<(RoomEdge OrientationGuideEdge, List<RoomEdge> WallCandidates)> wallCandidateOptions = null) where TSpaceBoundary : Element, ISpaceBoundary
+        {
+            // If a set of wall candidate options are provided, limit to the one that aligns with the boundary's first edge.
+            // In the future, as room shapes become more editable, we might want to pass in an explicit "orientation edge" instead of just using the first edge.
+            if (wallCandidateOptions != null)
+            {
+                var roomOrientationEdge = room.Boundary.Perimeter.Segments().First();
+                for (int i = wallCandidateOptions.Count - 1; i >= 0; i--)
+                {
+                    var (OrientationGuideEdge, _) = wallCandidateOptions[i];
+                    if (OrientationGuideEdge.Line.Mid().DistanceTo(roomOrientationEdge.Mid()) > 0.01)
+                    {
+                        wallCandidateOptions.RemoveAt(i);
+                    }
+                }
+            }
+
+            // Limit the possible configs to the one specified by the room's ConfigId property.
+            var configId = room.ConfigId;
+            var config = new SpaceConfiguration();
+            if (configs.ContainsKey(configId))
+            {
+                config.Add(configId, configs[configId]);
+                return config;
+            }
+
+            return configs;
         }
 
 

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -249,7 +249,7 @@ namespace LayoutFunctionCommon
         /// <summary>
         /// Pringle-specific behavior to pick a specific config and orientation. This code only executes if the room has a `ConfigId` property, which is only set on pringle.
         /// </summary>
-        public static SpaceConfiguration LimitConfigsToId<TSpaceBoundary>(SpaceConfiguration configs, TSpaceBoundary room, List<(RoomEdge OrientationGuideEdge, List<RoomEdge> WallCandidates)> wallCandidateOptions = null) where TSpaceBoundary : Element, ISpaceBoundary
+        public static SpaceConfiguration LimitConfigsToId<TSpaceBoundary>(SpaceConfiguration originalConfigs, TSpaceBoundary room, List<(RoomEdge OrientationGuideEdge, List<RoomEdge> WallCandidates)> wallCandidateOptions = null) where TSpaceBoundary : Element, ISpaceBoundary
         {
             // If a set of wall candidate options are provided, limit to the one that aligns with the boundary's first edge.
             // In the future, as room shapes become more editable, we might want to pass in an explicit "orientation edge" instead of just using the first edge.
@@ -266,16 +266,16 @@ namespace LayoutFunctionCommon
                 }
             }
 
-            // Limit the possible configs to the one specified by the room's ConfigId property.
+            // Limit the possible configs to the one specified by the room's ConfigId property, if it's found in the set.
             var configId = room.ConfigId;
-            var config = new SpaceConfiguration();
-            if (configs.ContainsKey(configId))
+            var newConfigs = new SpaceConfiguration();
+            if (originalConfigs.ContainsKey(configId))
             {
-                config.Add(configId, configs[configId]);
-                return config;
+                newConfigs.Add(configId, originalConfigs[configId]);
+                return newConfigs;
             }
 
-            return configs;
+            return originalConfigs;
         }
 
 

--- a/LayoutFunctions/LoungeLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/LoungeLayout/dependencies/SpaceBoundary.cs
@@ -1,9 +1,12 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
 
 namespace Elements
 {
     public partial class SpaceBoundary : ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }

--- a/LayoutFunctions/MeetingRoomLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/MeetingRoomLayout/dependencies/SpaceBoundary.cs
@@ -1,9 +1,11 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
 namespace Elements
 {
     public partial class SpaceBoundary : GeometricElement, ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
-
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }

--- a/LayoutFunctions/OpenCollabLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/OpenCollabLayout/dependencies/SpaceBoundary.cs
@@ -1,9 +1,11 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
 namespace Elements
 {
     public partial class SpaceBoundary : GeometricElement, ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
-
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }

--- a/LayoutFunctions/OpenOfficeLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/SpaceBoundary.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Elements.Geometry;
 using Elements.Geometry.Solids;
 using LayoutFunctionCommon;
+using Newtonsoft.Json;
 
 namespace Elements
 {

--- a/LayoutFunctions/OpenOfficeLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/OpenOfficeLayout/dependencies/SpaceBoundary.cs
@@ -24,6 +24,9 @@ namespace Elements
 
         public int SpaceCount { get; set; } = 1;
 
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; } // unused by this layout type
+
         [Newtonsoft.Json.JsonIgnore]
         public LevelElements LevelElements { get; set; }
 

--- a/LayoutFunctions/PantryLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/PantryLayout/dependencies/SpaceBoundary.cs
@@ -1,9 +1,13 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
+
 namespace Elements
 {
     public partial class SpaceBoundary : GeometricElement, ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
 
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }

--- a/LayoutFunctions/PhoneBoothLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/PhoneBoothLayout/dependencies/SpaceBoundary.cs
@@ -1,9 +1,13 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
 
 namespace Elements
 {
     public partial class SpaceBoundary : GeometricElement, ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
+        
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }

--- a/LayoutFunctions/PrivateOfficeLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/dependencies/SpaceBoundary.cs
@@ -1,4 +1,5 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
 
 namespace Elements
 {

--- a/LayoutFunctions/PrivateOfficeLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/dependencies/SpaceBoundary.cs
@@ -5,7 +5,10 @@ namespace Elements
     public partial class SpaceBoundary : GeometricElement, ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
-        
+
         public Vector3? IndividualCentroid { get; set; }
+
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }

--- a/LayoutFunctions/ReceptionLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/ReceptionLayout/dependencies/SpaceBoundary.cs
@@ -3,10 +3,14 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using Elements.Geometry;
+using Newtonsoft.Json;
+
 namespace Elements
 {
     public partial class SpaceBoundary : ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
+         [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }

--- a/SpaceConfigurationFromModel/dependencies/SpaceBoundary.cs
+++ b/SpaceConfigurationFromModel/dependencies/SpaceBoundary.cs
@@ -1,9 +1,12 @@
 using Elements.Geometry;
+using Newtonsoft.Json;
 namespace Elements
 {
     public partial class SpaceBoundary : GeometricElement, ISpaceBoundary
     {
         public Vector3? ParentCentroid { get; set; }
 
+        [JsonProperty("Config Id")]
+        public string ConfigId { get; set; }
     }
 }


### PR DESCRIPTION
An upcoming pringle PR displays the name (rather than just the dimensions) of layout variants, so a user may select "8P" in a meeting room to get an 8P meeting room. This change revealed some issues:
- because orientation was inconsistent, a different config than the one specified may get chosen.
- because the rooms match the config dimensions *exactly*, we might actually wind up with the next size down. 

This PR creates a pringle-specific pathway based on the existence of the `Config Id` property on a room, which is only set in Pringle. If this property is present:
- We limit the possible configs to the single one matching the config ID
- We force the orientation to use the first edge of the profile segment as its orientation edge

We also add a small amount of tolerance to the "fit" algorithm, so that an exact size match yields the correct type. 


I have tested this on Pringle in an [in-progress branch](https://github.com/hypar-io/pringle/pull/213) with the `Meeting Room` type. Other "named" configs for other types are less specific about precisely what you're going to see, so I didn't feel the need to update them, but when re-published they should do a better job of respecting the specified type name as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/88)
<!-- Reviewable:end -->
