### PR TITLE
filter wall candidates in 2d

### DIFF
--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -259,7 +259,7 @@ namespace LayoutFunctionCommon
                 for (int i = wallCandidateOptions.Count - 1; i >= 0; i--)
                 {
                     var (OrientationGuideEdge, _) = wallCandidateOptions[i];
-                    if (OrientationGuideEdge.Line.Mid().DistanceTo(roomOrientationEdge.Mid()) > 0.01)
+                    if (OrientationGuideEdge.Line.Mid().Project(Plane.XY).DistanceTo(roomOrientationEdge.Mid().Project(Plane.XY)) > 0.01)
                     {
                         wallCandidateOptions.RemoveAt(i);
                     }


### PR DESCRIPTION
The Pringle-specific code pathway was doing the wrong thing in the case of spaces not at z=0. It was filtering out wall candidate options in 3d, rather than 2d — this resulted in furniture not showing up for spaces not on the ground level.

I pushed this change to all classic layout functions in `test` but have not yet released.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/89)
<!-- Reviewable:end -->
