### PR TITLE
Use ""Partition" line as dominant is case if all lines are "Partition" to prevent exception

### DIFF
--- a/LayoutFunctions/LayoutFunctionCommon/WallGeneration.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/WallGeneration.cs
@@ -272,7 +272,13 @@ namespace LayoutFunctionCommon
                     resultCandidates.Add(candidate);
                     continue;
                 }
-                var linesOrderedByLength = collinearLinesGroup.Value.Where(x => !x.Item2.Contains("Partition")).OrderByDescending(v => v.Line.Length());
+                var filteredLines = collinearLinesGroup.Value.Where(x => !x.Item2.Contains("Partition"));
+                if (!filteredLines.Any())
+                {
+                    filteredLines = collinearLinesGroup.Value;
+                }
+
+                var linesOrderedByLength = filteredLines.OrderByDescending(v => v.Line.Length());
 
                 var dominantLineForGroup = linesOrderedByLength.FirstOrDefault(x => x.PrimaryEntryEdge == true);
 


### PR DESCRIPTION
InteriorPartitions function throws exception for line groups where all items have "Partition" type when
`dominantLineForGroup = linesOrderedByLength.First();` is executed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/92)
<!-- Reviewable:end -->
