### PR TITLE
Allow open collab spaces to have correct parent

### DIFF
--- a/LayoutFunctions/LayoutFunctionCommon/IHasParent.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/IHasParent.cs
@@ -1,0 +1,12 @@
+using System;
+using Elements.Geometry;
+
+namespace Elements
+{
+    public interface IHasParent
+    {
+        Guid? Parent { get; set; }
+
+        Polygon ParentBoundary { get; set; }
+    }
+}

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -909,22 +909,28 @@ namespace LayoutFunctionCommon
             {
                 foreach (var instance in componentInstance.Instances)
                 {
-                    if (instance != null)
-                    {
-                        instance.AdditionalProperties["Space"] = parentSpaceBoundary.Id;
-                        instance.AdditionalProperties["Space Boundary"] = parentSpaceBoundary.Boundary.Perimeter.TransformedPolygon(parentSpaceBoundary.Transform).Vertices;
-                    }
+                    SetParentSpace(instance, parentSpaceBoundary);
                 }
             }
         }
 
-        public static void SetParentSpace(ElementInstance elementInstance, ISpaceBoundary parentSpaceBoundary)
+        public static void SetParentSpace(Element element, ISpaceBoundary parentSpaceBoundary)
         {
-            if (elementInstance != null)
+            if (element is null)
             {
-                elementInstance.AdditionalProperties["Space"] = parentSpaceBoundary.Id;
-                elementInstance.AdditionalProperties["Space Boundary"] = parentSpaceBoundary.Boundary.Perimeter.TransformedPolygon(parentSpaceBoundary.Transform).Vertices;
+                return;
             }
+
+            var id = parentSpaceBoundary.Id;
+            var spaceBoundary = parentSpaceBoundary.Boundary.Perimeter.TransformedPolygon(parentSpaceBoundary.Transform);
+            if (parentSpaceBoundary is IHasParent childSpace)
+            {
+                id = childSpace.Parent ?? id;
+                spaceBoundary = childSpace.ParentBoundary ?? spaceBoundary;
+            }
+            element.AdditionalProperties["Space"] = id;
+            element.AdditionalProperties["Space Boundary"] = spaceBoundary.Vertices;
+
         }
 
         private static ContentConfiguration GetRotatedConfig(ContentConfiguration config, double degrees)

--- a/LayoutFunctions/OpenCollabLayout/dependencies/SpaceBoundary.cs
+++ b/LayoutFunctions/OpenCollabLayout/dependencies/SpaceBoundary.cs
@@ -1,11 +1,16 @@
+using System;
 using Elements.Geometry;
 using Newtonsoft.Json;
 namespace Elements
 {
-    public partial class SpaceBoundary : GeometricElement, ISpaceBoundary
+    public partial class SpaceBoundary : GeometricElement, ISpaceBoundary, IHasParent
     {
         public Vector3? ParentCentroid { get; set; }
         [JsonProperty("Config Id")]
         public string ConfigId { get; set; }
+
+        public Guid? Parent { get; set; }
+
+        public Polygon ParentBoundary { get; set; }
     }
 }

--- a/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayout.cs
+++ b/LayoutFunctions/OpenOfficeLayout/src/OpenOfficeLayout.cs
@@ -190,7 +190,7 @@ namespace OpenOfficeLayout
                             seatsCount += deskCount;
                             foreach (var profile in collabProfiles)
                             {
-                                var sb = SpaceBoundary.Make(profile, "Open Collaboration", ob.Transform.Concatenated(new Transform(0, 0, -0.03)), 3, profile.Perimeter.Centroid(), profile.Perimeter.Centroid());
+                                var sb = SpaceBoundary.Make(profile, "Open Collaboration", ob.Transform.Concatenated(new Transform(0, 0, -0.03)), 3, ob, profile.Perimeter.Centroid(), profile.Perimeter.Centroid());
                                 sb.Representation = new Representation(new[] { new Lamina(profile.Perimeter, false) });
                                 sb.AdditionalProperties.Add("Parent Level Id", lvl.Id);
                                 output.Model.AddElement(sb);


### PR DESCRIPTION
Open Collaboration furniture nestled in among open offices didn't show in pringle, because it didn't have a `Parent` space ID assigned (or it did, but it pointed to the "fake" open collaboration spaces produced by open office.) 

This PR allows those subsidiary spaces to be given a `Parent` id and `ParentBoundary`, which can be used to set the parent information on the furniture. 

I have published these changes in `test` versions of Open Office and Open Collaboration, and tested in pringle (by setting those two functions to `test`) and verified that the additional furniture now shows up. 