### PR TITLE
don't add a wall candidate element if there are no candidates

### DIFF
--- a/LayoutFunctions/ClassroomLayout/src/ClassroomLayout.cs
+++ b/LayoutFunctions/ClassroomLayout/src/ClassroomLayout.cs
@@ -154,7 +154,7 @@ namespace ClassroomLayout
                     output.Model.AddElement(new SpaceMetric(room.Id, seatsCount, 0, 0, 0));
                 }
                 var height = meetingRmBoundaries.FirstOrDefault()?.Height ?? 3;
-                if (input.CreateWalls)
+                if (input.CreateWalls && wallCandidateLines.Any())
                 {
                     output.Model.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
                     {

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutGeneration.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutGeneration.cs
@@ -104,7 +104,7 @@ namespace LayoutFunctionCommon
                 double height = levelVolume?.Height ?? 3;
                 Transform xform = levelVolume?.Transform ?? new Transform();
 
-                if (createWalls)
+                if (createWalls && wallCandidateLines.Count > 0)
                 {
                     outputModel.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
                     {

--- a/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
+++ b/LayoutFunctions/LayoutFunctionCommon/LayoutStrategies.cs
@@ -328,12 +328,15 @@ namespace LayoutFunctionCommon
                     double height = room.Height == 0 ? 3 : room.Height;
                     Transform xform = levelVolume?.Transform ?? new Transform();
 
-                    outputModel.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
+                    if (wallCandidateLines.Count > 0)
                     {
-                        WallCandidateLines = wallCandidateLines,
-                        Height = height,
-                        LevelTransform = xform,
-                    });
+                        outputModel.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
+                        {
+                            WallCandidateLines = wallCandidateLines,
+                            Height = height,
+                            LevelTransform = xform,
+                        });
+                    }
                 }
             }
             foreach (var room in allSpaceBoundaries)

--- a/LayoutFunctions/PhoneBoothLayout/src/PhoneBoothLayout.cs
+++ b/LayoutFunctions/PhoneBoothLayout/src/PhoneBoothLayout.cs
@@ -127,7 +127,7 @@ namespace PhoneBoothLayout
                     output.Model.AddElement(new SpaceMetric(room.Id, seatsCount, 0, 0, 0));
                 }
                 var height = meetingRmBoundaries.FirstOrDefault()?.Height ?? 3;
-                if (input.CreateWalls)
+                if (input.CreateWalls && wallCandidateLines.Count > 0)
                 {
                     output.Model.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
                     {

--- a/LayoutFunctions/PrivateOfficeLayout/src/PrivateOfficeLayout.cs
+++ b/LayoutFunctions/PrivateOfficeLayout/src/PrivateOfficeLayout.cs
@@ -155,12 +155,15 @@ namespace PrivateOfficeLayout
                 }
 
                 var height = privateOfficeBoundaries.FirstOrDefault()?.Height ?? 3;
-                output.Model.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
+                if (wallCandidateLines.Count > 0)
                 {
-                    WallCandidateLines = wallCandidateLines,
-                    Height = height,
-                    LevelTransform = levelVolume?.Transform ?? new Transform()
-                });
+                    output.Model.AddElement(new InteriorPartitionCandidate(Guid.NewGuid())
+                    {
+                        WallCandidateLines = wallCandidateLines,
+                        Height = height,
+                        LevelTransform = levelVolume?.Transform ?? new Transform()
+                    });
+                }
             }
             output.PrivateOfficeCount = totalPrivateOfficeCount;
             OverrideUtilities.InstancePositionOverrides(input.Overrides, output.Model);


### PR DESCRIPTION
After [this change ](https://github.com/hypar-io/Elements/pull/1058) in elements. Revit started deserializing these elements correctly, and then therefore always reporting that layout functions were loading even when there were no actual elements that were valid for loading. This is because we were always adding a InteriorPartitionCandidate element, even when there were no actual partition candidates.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/98)
<!-- Reviewable:end -->
