### PR TITLE
rounded Z values

### DIFF
--- a/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
+++ b/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
@@ -31,8 +31,15 @@ namespace WallsLOD200
                 {
                     var level = levels.FirstOrDefault(l => l.Id.ToString() == group.Key.ToString()) ?? new Level(0, 3, null);
                     var lines = UnifyLines(group.ToList().Select(g => g.CenterLine).ToList());
-                    var newwalls = lines.Select(mc => new StandardWall(mc, 0.1, level.Height ?? 3, random.NextMaterial(), new Transform().Moved(0, 0, level.Elevation)));
-                    output.Model.AddElements(newwalls);
+                    var roundedZLines = lines.Select(l =>
+                        {
+                            var roundedStart = new Vector3(l.Start.X, l.Start.Y, Math.Round(l.Start.Z, 5));
+                            var roundedEnd = new Vector3(l.End.X, l.End.Y, Math.Round(l.End.Z, 5));
+                            return new Line(roundedStart, roundedEnd);
+                        }
+                    );
+                    var newWalls = roundedZLines.Select(mc => new StandardWall(mc, 0.1, level.Height ?? 3, random.NextMaterial(), new Transform().Moved(0, 0, level.Elevation)));
+                    output.Model.AddElements(newWalls);
                 }
             }
 


### PR DESCRIPTION
got some hy-ccup alerts regarding walls LOD200
we should do rounding to make sure our walls function doesn't error. 
We should also see if we can make the pringle not make bad geometry, but this might still be a good idea.

this workflow shows the error, you can toggle test on/off for walls LOD 200 to see the fix
https://hypar.io/workflows/57e786c9-9c8e-446b-a337-6b27aa858506?api=staging 