### PR TITLE
handle tolerance gaps for WallsLOD200

### DIFF
--- a/LayoutFunctions/WallsLOD200/dependencies/WallsLOD200.Dependencies.csproj
+++ b/LayoutFunctions/WallsLOD200/dependencies/WallsLOD200.Dependencies.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="2.1.0" />
+    <PackageReference Include="Hypar.Elements" Version="2.2.0-alpha.29" />
     <PackageReference Include="Hypar.Functions" Version="1.10.0" />
   </ItemGroup>
 

--- a/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
+++ b/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
@@ -5,6 +5,7 @@ namespace WallsLOD200
 {
     public static partial class WallsLOD200
     {
+        public static double tolerance = 0.0001;
         /// <summary>
         /// The WallsLOD200 function.
         /// </summary>
@@ -114,17 +115,31 @@ namespace WallsLOD200
                         {
                             Line otherLine = mergedLines[j];
 
-                            if (line.TryGetOverlap(otherLine, out var overlap) || line.DistanceTo(otherLine) < 0.0001)
+                            try
                             {
-                                // Merge collinear lines
-                                Line mergedLine = line.MergedCollinearLine(otherLine);
+                                if (line.TryGetOverlap(otherLine, out var overlap) || line.DistanceTo(otherLine) < tolerance)
+                                {
+                                    // project lines within tolerance but further than epsilon
+                                    if (line.DistanceTo(otherLine) > double.Epsilon)
+                                    {
+                                        otherLine = otherLine.Projected(line);
+                                    }
+                                    // Merge collinear lines
+                                    Line mergedLine = line.MergedCollinearLine(otherLine);
 
-                                // Update the list with the merged line
-                                mergedLines.RemoveAt(j);
-                                mergedLines[i] = mergedLine;
+                                    // Update the list with the merged line
+                                    mergedLines.RemoveAt(j);
+                                    mergedLines[i] = mergedLine;
 
-                                linesMerged = true;
-                                break; // Exit the inner loop as we have merged the lines
+                                    linesMerged = true;
+                                    break; // Exit the inner loop as we have merged the lines
+                                }
+                            }
+                            catch (Exception e)
+                            {
+                                Console.WriteLine($"Failed to merge wall line {otherLine.Start} - {otherLine.End}.");
+                                Console.WriteLine(e.Message);
+                                Console.WriteLine(e.StackTrace);
                             }
                         }
                         if (linesMerged)

--- a/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
+++ b/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
@@ -115,31 +115,22 @@ namespace WallsLOD200
                         {
                             Line otherLine = mergedLines[j];
 
-                            try
+                            if (line.TryGetOverlap(otherLine, out var overlap) || line.DistanceTo(otherLine) < tolerance)
                             {
-                                if (line.TryGetOverlap(otherLine, out var overlap) || line.DistanceTo(otherLine) < tolerance)
+                                // project lines within tolerance but further than epsilon
+                                if (line.DistanceTo(otherLine) > double.Epsilon)
                                 {
-                                    // project lines within tolerance but further than epsilon
-                                    if (line.DistanceTo(otherLine) > double.Epsilon)
-                                    {
-                                        otherLine = otherLine.Projected(line);
-                                    }
-                                    // Merge collinear lines
-                                    Line mergedLine = line.MergedCollinearLine(otherLine);
-
-                                    // Update the list with the merged line
-                                    mergedLines.RemoveAt(j);
-                                    mergedLines[i] = mergedLine;
-
-                                    linesMerged = true;
-                                    break; // Exit the inner loop as we have merged the lines
+                                    otherLine = otherLine.Projected(line);
                                 }
-                            }
-                            catch (Exception e)
-                            {
-                                Console.WriteLine($"Failed to merge wall line {otherLine.Start} - {otherLine.End}.");
-                                Console.WriteLine(e.Message);
-                                Console.WriteLine(e.StackTrace);
+                                // Merge collinear lines
+                                Line mergedLine = line.MergedCollinearLine(otherLine);
+
+                                // Update the list with the merged line
+                                mergedLines.RemoveAt(j);
+                                mergedLines[i] = mergedLine;
+
+                                linesMerged = true;
+                                break; // Exit the inner loop as we have merged the lines
                             }
                         }
                         if (linesMerged)


### PR DESCRIPTION
We were allowing walls within a certain distance threshold to be merged if they were collinear, however this made the mergedcollinear method upset because those walls were too far. This PR projects those wall lines that are too far.

Tested against multiple workflows that that threw a WallsLOD200 Hy-ccups:
https://hypar.io/workflows/4c4eb24a-37d6-49e2-bc48-a291462d274f?api=staging
https://hypar.io/workflows/56fd3882-549f-4690-8846-8c8351eb7fa0?api=staging
https://hypar.io/workflows/7304eda5-1718-4c35-a103-52c2ee35263e?api=staging

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/100)
<!-- Reviewable:end -->
