### PR TITLE
check points for distance instead

### DIFF
--- a/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
+++ b/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
@@ -124,8 +124,8 @@ namespace WallsLOD200
 
                             if (line.TryGetOverlap(otherLine, out var overlap) || line.DistanceTo(otherLine) < tolerance)
                             {
-                                // project lines within tolerance but further than epsilon
-                                if (line.DistanceTo(otherLine) > double.Epsilon)
+                                // project lines with points within tolerance of eachother but further than epsilon
+                                if (LinesWithinTolerance(line, otherLine, tolerance))
                                 {
                                     otherLine = otherLine.Projected(line);
                                 }
@@ -147,6 +147,29 @@ namespace WallsLOD200
                 merged.AddRange(mergedLines);
             }
             return merged;
+        }
+
+        public static bool LinesWithinTolerance(Line line1, Line line2, double tolerance)
+        {
+            // Calculate distances between all point pairs
+            var distances = new List<double>()
+            {
+                line1.Start.DistanceTo(line2.Start),
+                line1.Start.DistanceTo(line2.End),
+                line1.End.DistanceTo(line2.Start),
+                line1.End.DistanceTo(line2.End)
+            };
+
+            // Check if any distance is within the tolerance but larger than double.Epsilon
+            foreach (var distance in distances)
+            {
+                if (distance > double.Epsilon && distance <= tolerance)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
+++ b/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
@@ -124,7 +124,8 @@ namespace WallsLOD200
                             {
                                 // we project the lines because line.IsCollinear resolves to true on
                                 // near 0 differences which MergedCollinearLine does not tolerate
-                                // line.DistanceTo is similarly fuzzy and resolves to 0 on near (but greater than epsilon) distances
+                                // originally we validated if projection was necessary using line.DistanceTo,
+                                // but it is similarly fuzzy and resolves to 0 on near (but greater than epsilon) distances
                                 otherLine = otherLine.Projected(line);
                                 Line mergedLine = line.MergedCollinearLine(otherLine);
 


### PR DESCRIPTION
Evidently using the distance from one line to another was not sufficient to determine if projection was needed. This PR compares the end points of the lines for to determine if they are within tolerance, but further than epsilon, and thus needs projection.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/101)
<!-- Reviewable:end -->
