### PR TITLE
cull lines shorter than tolerance

### DIFF
--- a/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
+++ b/LayoutFunctions/WallsLOD200/src/WallsLOD200.cs
@@ -161,7 +161,11 @@ namespace WallsLOD200
 
             foreach (Line line in lines)
             {
-                uniqueLines.Add(line);
+                // Don't include lines that have a near 0 length
+                if (line.Length() > tolerance)
+                {
+                    uniqueLines.Add(line);
+                }
             }
 
             return uniqueLines.ToList();


### PR DESCRIPTION
It's possible to make lines that are nearly zero length in Pringle, after processing these lines can end up having the same start and end points. This PR removes those nearly zero length lines during our dedup step

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/106)
<!-- Reviewable:end -->
