### PR TITLE
Wallslod200 fix overlap bugs

### DIFF
--- a/LayoutFunctions/WallsLOD200/dependencies/OverlapIndex.cs
+++ b/LayoutFunctions/WallsLOD200/dependencies/OverlapIndex.cs
@@ -13,6 +13,7 @@ public readonly record struct FatLine(Line Centerline, double Thickness);
 /// </summary>
 public class OverlapMergeGroup<T>
 {
+    private const double MinSliceLength = 0.1;
     /// <summary>
     /// The original items in this group.
     /// </summary>
@@ -52,6 +53,14 @@ public class OverlapMergeGroup<T>
             if (s1 - s0 < Vector3.EPSILON)
             {
                 continue;            // zero-length slot
+            }
+
+            // if projected length is too small, skip it entirely:
+            if ((s1 - s0) < MinSliceLength)
+            {
+                // do NOT start or extend any “open” fat‐line here
+                // let the next interval (if it exists) reconnect as needed.
+                continue;
             }
 
             // 2.  which segments cover [s0,s1]?

--- a/LayoutFunctions/WallsLOD200/dependencies/OverlapIndex.cs
+++ b/LayoutFunctions/WallsLOD200/dependencies/OverlapIndex.cs
@@ -193,12 +193,12 @@ public class OverlapIndex<T>(double angleTolerance = 1e-3, double longTolerance 
                 }
                 else                                   // gap ⇒ close cluster
                 {
-                    EmitLongitudinalGroups(currentCluster, result);
+                    EmitLongitudinalGroups(currentCluster, result, thicknessTolerance);
                     currentCluster = [seg];
                     currentHigh = high;
                 }
             }
-            EmitLongitudinalGroups(currentCluster, result);
+            EmitLongitudinalGroups(currentCluster, result, thicknessTolerance);
         }
 
         return result;
@@ -262,8 +262,9 @@ public class OverlapIndex<T>(double angleTolerance = 1e-3, double longTolerance 
     /// <param name="cluster">Cluster of segments to process</param>
     /// <param name="sink">Collection to add resulting groups to</param>
     private void EmitLongitudinalGroups(
-    List<SegmentRecord<T>> cluster,
-    List<OverlapMergeGroup<T>> sink)
+        List<SegmentRecord<T>> cluster,
+        List<OverlapMergeGroup<T>> sink,
+        double thicknessTolerance)
     {
         if (cluster.Count == 0)
         {
@@ -274,23 +275,70 @@ public class OverlapIndex<T>(double angleTolerance = 1e-3, double longTolerance 
         cluster.Sort((a, b) => a.MinS.CompareTo(b.MinS));
 
         var current = new List<SegmentRecord<T>>();
-        double currentMax = double.NegativeInfinity;
+        double currentMinS = double.PositiveInfinity;
+        double currentMaxS = double.NegativeInfinity;
+        double groupOffsetMin = 0;
+        double groupOffsetMax = 0;
+        double refOffset = double.NaN; // centerline offset of the first segment
 
         foreach (var seg in cluster)
         {
-            if (seg.MinS <= currentMax + _longTolerance)        // overlaps current set
+            double segLowOffset = seg.Offset - seg.OffsetTolerance - thicknessTolerance;
+            double segHighOffset = seg.Offset + seg.OffsetTolerance + thicknessTolerance;
+
+            if (current.Count == 0)
             {
-                current.Add(seg);
-                currentMax = Math.Max(currentMax, seg.MaxS);
+                current = new List<SegmentRecord<T>> { seg };
+                currentMinS = seg.MinS;
+                currentMaxS = seg.MaxS;
+                groupOffsetMin = segLowOffset;
+                groupOffsetMax = segHighOffset;
+                refOffset = seg.Offset;
             }
             else
             {
-                if (current.Count > 0)
+                // compute overlaps
+                double overlapMinS = Math.Max(seg.MinS, currentMinS);
+                double overlapMaxS = Math.Min(seg.MaxS, currentMaxS);
+                double sOverlapLen = overlapMaxS - overlapMinS;
+                double offsetOverlapLow = Math.Max(segLowOffset, groupOffsetMin);
+                double offsetOverlapHigh = Math.Min(segHighOffset, groupOffsetMax);
+                double offsetOverlapLen = offsetOverlapHigh - offsetOverlapLow;
+
+                // check if centerlines are effectively collinear (within perp‐tol)
+                bool collinear = Math.Abs(seg.Offset - refOffset) <= seg.OffsetTolerance;
+
+                bool shouldMerge = false;
+                if (collinear)
+                {
+                    // collinear: allow S intervals to touch (zero-length) within longitude tolerance
+                    shouldMerge = (sOverlapLen + _longTolerance) >= 0;
+                }
+                else
+                {
+                    // parallel-but-distinct: offset intervals must overlap (or touch),
+                    // and S must have positive overlap
+                    shouldMerge = (offsetOverlapLen >= -1e-6) && (sOverlapLen > _longTolerance);
+                }
+
+                if (shouldMerge)
+                {
+                    current.Add(seg);
+                    currentMinS = Math.Min(currentMinS, seg.MinS);
+                    currentMaxS = Math.Max(currentMaxS, seg.MaxS);
+                    groupOffsetMin = Math.Min(groupOffsetMin, segLowOffset);
+                    groupOffsetMax = Math.Max(groupOffsetMax, segHighOffset);
+                }
+                else
                 {
                     sink.Add(new OverlapMergeGroup<T>(current));
+                    current = new List<SegmentRecord<T>> { seg };
+                    currentMinS = seg.MinS;
+                    currentMaxS = seg.MaxS;
+                    groupOffsetMin = segLowOffset;
+                    groupOffsetMax = segHighOffset;
+                    refOffset = seg.Offset;
                 }
-                current = [seg];
-                currentMax = seg.MaxS;
             }
         }
         if (current.Count > 0)

--- a/LayoutFunctions/WallsLOD200/test/OverlapIndexTest.cs
+++ b/LayoutFunctions/WallsLOD200/test/OverlapIndexTest.cs
@@ -1,6 +1,4 @@
-using Xunit;
 using Elements.Geometry;
-using System.Linq;
 
 namespace WallsLOD200.Tests;
 
@@ -184,5 +182,49 @@ public class OverlapIndexTest
         var groups = idx.GetOverlapGroups();
         Assert.Single(groups);
 
+    }
+
+    [Fact]
+    public void OverlapIndex_DoesNotMergeFatLinesSeparatedByGap()
+    {
+        var inputFatLines = new (Line line, double thickness)[]
+            {
+                // Fatlines that touch edge to edge
+                (new Line((-1,1), (-1, 5)), 2),
+                (new Line((1,1), (1, 5)), 2),
+
+                // Fatlines with a 1 unit gap between their edges
+                (new Line((-1,-5), (-1, 0)), 1),
+                (new Line((1,-5), (1, 0)), 1),
+            };
+
+        var idx = new OverlapIndex<Line>();
+        foreach (var (line, thickness) in inputFatLines)
+        {
+            idx.AddItem(line, line, thickness);
+        }
+
+        var groups = idx.GetOverlapGroups();
+        Assert.Equal(3, groups.Count);
+    }
+
+    [Fact]
+    public void OverlapIndex_DoesNotMergeFatLinesOnMinorOverlap()
+    {
+        var inputFatLines = new (Line line, double thickness)[]
+            {
+                // Fatlines that just barely overlap on edge
+                (new Line((0,0), (0, 5)), .1),
+                (new Line((0.08,-5), (0.08, 0)), .1),
+            };
+
+        var idx = new OverlapIndex<Line>();
+        foreach (var (line, thickness) in inputFatLines)
+        {
+            idx.AddItem(line, line, thickness);
+        }
+
+        var groups = idx.GetOverlapGroups();
+        Assert.Equal(2, groups.Count);
     }
 }

--- a/LayoutFunctions/WallsLOD200/test/OverlapIndexTest.cs
+++ b/LayoutFunctions/WallsLOD200/test/OverlapIndexTest.cs
@@ -229,7 +229,7 @@ public class OverlapIndexTest
     }
 
     [Fact]
-    public void OverlapIndex_MergesFatLinesOnCenterLineMove()
+    public void Absorbs_Thin_OverlapSegments()
     {
         var inputWalls = new Elements.StandardWall[]
         {
@@ -254,5 +254,22 @@ public class OverlapIndexTest
         Assert.Equal(3, groups.Count);
         var total = groups.Sum(g => g.FatLines.Count);
         Assert.Equal(3, groups.Sum(g => g.FatLines.Count));
+
+        var lines = new (Line line, double thickness)[] {
+           (new((0,0), (1,0)), 0.2),
+           (new ((0.5, 0), (1.5, 0)), 0.05),
+           (new ((1.01, 0), (2, 0)), 0.2),
+        };
+
+        var idxLines = new OverlapIndex<Line>();
+        foreach (var (line, thickness) in lines)
+        {
+            idxLines.AddItem(line, line, thickness);
+        }
+
+        var lineGroups = idxLines.GetOverlapGroups();
+        Assert.Single(lineGroups);
+        var group = lineGroups.First();
+        Assert.Single(group.FatLines);
     }
 }

--- a/LayoutFunctions/WallsLOD200/test/OverlapIndexTest.cs
+++ b/LayoutFunctions/WallsLOD200/test/OverlapIndexTest.cs
@@ -227,4 +227,32 @@ public class OverlapIndexTest
         var groups = idx.GetOverlapGroups();
         Assert.Equal(2, groups.Count);
     }
+
+    [Fact]
+    public void OverlapIndex_MergesFatLinesOnCenterLineMove()
+    {
+        var inputWalls = new Elements.StandardWall[]
+        {
+            new Elements.StandardWall(new Line((1.100000, 1.112500, 0.000000), (1.100000, 2.262500, 0.000000)), 0.200000, 3.048000, null, wallsVersion: "3"),
+            new Elements.StandardWall(new Line((1.100000, 2.287500, 0.000000), (1.100000, 3.350000, 0.000000)), 0.200000, 3.048000, null, wallsVersion: "3"),
+            new Elements.StandardWall(new Line((1.137500, 3.350000, 0.000000), (1.137500, -0.000000, 0.000000)), 0.125000, 3.048000, null, wallsVersion: "3"),
+            new Elements.StandardWall(new Line((1.100000, 1.087500, 0.000000), (0.000000, 1.087500, 0.000000)), 0.175000, 3.048000, null, wallsVersion: "3"),
+            new Elements.StandardWall(new Line((1.100000, 2.262500, 0.000000), (0.000000, 2.262500, 0.000000)), 0.175000, 3.048000, null, wallsVersion: "3"),
+            new Elements.StandardWall(new Line((0.000000, 1.112500, 0.000000), (1.100000, 1.112500, 0.000000)), 0.125000, 3.048000, null, wallsVersion: "3"),
+            new Elements.StandardWall(new Line((1.100000, -0.000000, 0.000000), (1.100000, 1.087500, 0.000000)), 0.200000, 3.048000, null, wallsVersion: "3"),
+            new Elements.StandardWall(new Line((0.000000, 2.287500, 0.000000), (1.100000, 2.287500, 0.000000)), 0.125000, 3.048000, null, wallsVersion: "3"),
+        };
+
+        var idx = new OverlapIndex<Elements.StandardWall>();
+        foreach (var wall in inputWalls)
+        {
+            var transformedLine = wall.CenterLine.TransformedLine(wall.Transform);
+            idx.AddItem(wall, transformedLine, wall.Thickness);
+        }
+
+        var groups = idx.GetOverlapGroups();
+        Assert.Equal(3, groups.Count);
+        var total = groups.Sum(g => g.FatLines.Count);
+        Assert.Equal(3, groups.Sum(g => g.FatLines.Count));
+    }
 }


### PR DESCRIPTION
Kat identified a condition where we would allow skinny segments of walls to survive fatlining. While looking into a resolution for this issue there were 2 other cases that resulted in merges that shouldn't have been happening either.

Tests for all 3 conditions have been added and solutions verified using classic.

Before:
<img width="947" alt="Screenshot 2025-06-03 at 10 04 45 AM" src="https://github.com/user-attachments/assets/694038e0-2dc9-43fa-9f9f-5f682d8da4f8" />

After:
<img width="908" alt="Screenshot 2025-06-03 at 10 05 20 AM" src="https://github.com/user-attachments/assets/55952570-dfbe-426c-95e8-9c3783b594ea" />

<img width="1174" alt="Screenshot 2025-06-03 at 10 05 54 AM" src="https://github.com/user-attachments/assets/d49bb283-a7de-44d7-9eb4-7b68b6f87120" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/HyparSpace/112)
<!-- Reviewable:end -->
